### PR TITLE
Add support for accessing device registers

### DIFF
--- a/driver/calc_driver.c
+++ b/driver/calc_driver.c
@@ -22,8 +22,6 @@ static int calc_major;
 
 struct calc_device_data {
     struct cdev cdev;
-    long var;
-    unsigned int curr_op;
     void* __iomem base;
 };
 
@@ -160,9 +158,6 @@ static int calc_driver_probe(struct platform_device *pdev)
         printk(KERN_ERR "calc_driver: cdev_add failed\n");
         goto err_min_ret;
     }
-
-    data->var = 0;
-    data->curr_op = ADD;
 
     mem_res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
     if (IS_ERR(mem_res)) {

--- a/driver/calc_driver.c
+++ b/driver/calc_driver.c
@@ -46,6 +46,11 @@ static int calc_open(struct inode *inode, struct file *file)
     return 0;
 }
 
+static inline void* __iomem get_base_ptr(struct file *file)
+{
+    return ((struct calc_device_data*)file->private_data)->base;
+}
+
 static ssize_t calc_read(struct file *file, char __user *buf, size_t count, loff_t *offset)
 {
     struct calc_device_data *calc_data = (struct calc_device_data *)file->private_data;
@@ -62,8 +67,7 @@ static ssize_t calc_write(struct file *file, const char __user *buf, size_t coun
 {
     u32 old_data_reg1, user_data = 0;
     size_t buf_size = count < sizeof(user_data) ? count : sizeof(user_data);
-    struct calc_device_data *calc_data = (struct calc_device_data *)file->private_data;
-    void* base_ptr = calc_data->base;
+    void* base_ptr = get_base_ptr(file);
 
     if(copy_from_user(&user_data, buf, buf_size))
         return -EFAULT;    
@@ -78,8 +82,7 @@ static ssize_t calc_write(struct file *file, const char __user *buf, size_t coun
 
 static long calc_ioctl (struct file *file, unsigned int cmd, unsigned long arg) 
 {
-    struct calc_device_data *calc_data = (struct calc_device_data *)file->private_data;
-    void* base_ptr = calc_data->base;
+    void* base_ptr = get_base_ptr(file);
     u32 status;
     
     switch(cmd) {

--- a/driver/calc_driver.c
+++ b/driver/calc_driver.c
@@ -15,9 +15,11 @@
 #define DAT1_REG_OFFSET      0x0c
 #define RESULT_REG_OFFSET    0x10
 
+static int calc_major;
+
 #define CALC_MAX_MINORS 3
 
-static int calc_major;
+static unsigned char calc_minors[CALC_MAX_MINORS] = {0};
 
 
 struct calc_device_data {
@@ -117,8 +119,6 @@ const struct file_operations calc_fops = {
     .unlocked_ioctl = calc_ioctl,
     .release = calc_release
 };
-
-static unsigned char calc_minors[CALC_MAX_MINORS] = {0};
 
 static int get_calc_minor(void)
 {

--- a/driver/calc_driver.c
+++ b/driver/calc_driver.c
@@ -53,10 +53,11 @@ static inline void* __iomem get_base_ptr(struct file *file)
 
 static ssize_t calc_read(struct file *file, char __user *buf, size_t count, loff_t *offset)
 {
-    struct calc_device_data *calc_data = (struct calc_device_data *)file->private_data;
-    size_t buf_size = count < (sizeof(calc_data->var) - *offset) ? count : (sizeof(calc_data->var) - *offset);
+    void* base_ptr = get_base_ptr(file);
+    u32 result = read_addr(base_ptr + RESULT_REG_OFFSET);
+    size_t buf_size = count < (sizeof(result) - *offset) ? count : (sizeof(result) - *offset);
     
-    if(copy_to_user(buf, &calc_data->var, sizeof(long)))
+    if(copy_to_user(buf, &result, sizeof(result)))
         return -EFAULT;
 
     *offset += buf_size;

--- a/driver/calc_driver.c
+++ b/driver/calc_driver.c
@@ -138,7 +138,8 @@ static int calc_driver_probe(struct platform_device *pdev)
     data = devm_kzalloc(&pdev->dev, sizeof(struct calc_device_data), GFP_KERNEL);
     if (!data) {
         printk(KERN_ERR "calc_driver: unable to allocate driver data\n");
-        return -ENOMEM;
+        ret = -ENOMEM;
+        goto err_min_ret;
     }
 
     cdev_init(&data->cdev, &calc_fops);

--- a/driver/calc_driver.c
+++ b/driver/calc_driver.c
@@ -6,6 +6,7 @@
 #include <linux/cdev.h>
 #include <linux/ioport.h>
 #include <asm/ioctl.h>
+#include <asm/io.h>
 #include "calc_driver.h"
 
 #define CALC_MAX_MINORS 3
@@ -19,6 +20,17 @@ struct calc_device_data {
     unsigned int curr_op;
     void* __iomem base;
 };
+
+
+static inline void write_addr(u32 val, void __iomem *addr)
+{
+    writel((u32 __force)cpu_to_le32(val), addr);
+}
+
+static inline u32 read_addr(void __iomem *addr)
+{
+    return le32_to_cpu(( __le32 __force)readl(addr));
+}
 
 static int calc_open(struct inode *inode, struct file *file)
 {

--- a/driver/calc_driver.h
+++ b/driver/calc_driver.h
@@ -1,12 +1,17 @@
 #ifndef _CALC_DRIVER_H
 #define _CALC_DRIVER_H
 
-#define ADD 0
-#define SUB 1
-#define MUL 2
-#define DIV 3
+#define ADD (1 << 0)
+#define SUB (1 << 1)
+#define MUL (1 << 2)
+#define DIV (1 << 3)
 
-#define CALC_IOCTL_RESET _IO('M', 0)
-#define CALC_IOCTL_CHANGE_OP _IOW('M', 1, long)
+#define STATUS_INV_OP   (1 << 0)
+#define STATUS_DIV_ZERO (1 << 1)
+#define STATUS_MASK_ALL (STATUS_INV_OP | STATUS_DIV_ZERO)
+
+#define CALC_IOCTL_RESET        _IO('C', 0)
+#define CALC_IOCTL_CHANGE_OP    _IOW('C', 1, long)
+#define CALC_IOCTL_CHECK_STATUS _IOR('C', 2, long)
 
 #endif

--- a/driver/test_app.c
+++ b/driver/test_app.c
@@ -9,6 +9,26 @@
 #include"calc_driver.h"
 
 
+/* Calculate the result of "`num1` `op` `num2`".
+ * If an error occured, return its code or 0 elsewhere
+ */
+int calculate(int fd, long num1, long num2, long op, long* result) {
+    long err = 0;
+    
+    write(fd, &num1, sizeof(num1));
+    write(fd, &num2, sizeof(num2));
+    ioctl(fd, CALC_IOCTL_CHANGE_OP, op);
+
+    ioctl(fd, CALC_IOCTL_CHECK_STATUS, &err);
+    if (err & STATUS_MASK_ALL) {
+        ioctl(fd, CALC_IOCTL_RESET);
+        return err;
+    }
+
+    read(fd, result, sizeof(result));
+    return 0;
+}
+
 static int is_chardev(const char* filename) {
     struct stat file_stat;
 
@@ -18,7 +38,7 @@ static int is_chardev(const char* filename) {
 
 int main(int argc, const char* argv[]) {
     int fd, res;
-    long var, num_to_send;
+    long result;
 
     if (argc != 2) {
         fprintf(stderr, "usage: %s <char_dev_file>\n", argv[0]);
@@ -32,31 +52,17 @@ int main(int argc, const char* argv[]) {
     fd = open(argv[1], O_RDWR);
     assert(fd > 0);
 
-    res = read(fd, &var, sizeof(long));
-    printf("Var initially: %ld\n", var);
+    res = calculate(fd, 15, 34, ADD, &result);
+    assert(res == 0 && result == 49);
+    res = calculate(fd, 4, 34, MUL, &result);
+    assert(res == 0 && result == 136);
+    res = calculate(fd, 2, 0, DIV, &result);
+    assert(res == STATUS_DIV_ZERO);
+    res = calculate(fd, 1234, 4321, SUB, &result);
+    assert(res == 0 && result == -3087);
+    res = calculate(fd, 6, 5, 100, &result);
+    assert(res == STATUS_INV_OP);
 
-    num_to_send = 15;
-    res = write(fd, &num_to_send, sizeof(long));
-    assert(res > 0);
-    num_to_send = 34;
-    res = write(fd, &num_to_send, sizeof(long));
-    assert(res > 0);
-
-    res = read(fd, &var, sizeof(long));
-    assert(res >= 0);
-    printf("15 + 34 = %ld\n", var);
-
-    res = ioctl(fd, CALC_IOCTL_CHANGE_OP, MUL);
-    assert(res >= 0);
-
-    num_to_send = 49;
-    res = write(fd, &num_to_send, sizeof(long));
-    assert(res > 0);
-
-    res = read(fd, &var, sizeof(long));
-    assert(res >= 0);
-    printf("49 * 49 = %ld\n", var);
-    
     close(fd);
     return 0;
 }


### PR DESCRIPTION
Up to this point the driver was essentially emulating the behavior of the device, since all the calculations were performed using internal driver state (`calc_data->curr_op` and `calc_data->result` fields).
This PR implements support for interacting with the device by means of:
* memory space mapping
* accessing device registers 