### PR TITLE
CI setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+build/*
+renode_portable/*
+third_party/*
+.git/*

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -21,3 +21,7 @@ jobs:
         run: |
           cd driver
           make dtb
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Kernel modules
+          path: driver/*.ko

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,17 +4,20 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Module & dtb & test app build
+    name: Builds
     runs-on: ubuntu-latest
     container: panantoni01/linux-drivers:squashed
     steps:
       - uses: actions/checkout@v4
-      - run: |
+      - name: Build modules
+        run: |
           cd driver
           make modules
-      - run: |
+      - name: Build test app
+        run: |
           cd driver
           make test
-      - run: |
+      - name: Build dtb
+        run: |
           cd driver
           make dtb

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,20 @@
+name: Linux Virtual Driver
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Module & dtb & test app build
+    runs-on: ubuntu-latest
+    container: panantoni01/linux-drivers:squashed
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          cd driver
+          make modules
+      - run: |
+          cd driver
+          make test
+      - run: |
+          cd driver
+          make dtb

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ build
 Module.symvers
 modules.order
 test_app
+*.dtb
 .vscode/*
 .gdb*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:bookworm
+
+WORKDIR /root
+
+ENV ARCH=riscv
+ENV CROSS_COMPILE=riscv32-linux-
+
+# Install necessary packages
+RUN apt-get update -y
+RUN apt-get install -y --no-install-recommends device-tree-compiler git build-essential wget ca-certificates file \
+        cpio unzip rsync bc flex curl python3
+# Copy buildroot and linux config files
+RUN mkdir -p $(pwd)/build/{buildroot,linux}
+COPY config/buildroot_config build/buildroot/.config
+COPY config/linux_config build/linux/.config
+# Build buildroot - commit hash e889a1c9e983753dd0fa5062d3b9475a8cba6072
+RUN git clone https://github.com/buildroot/buildroot.git && cd buildroot && git reset --hard e889a1c9e9 && cd ../
+RUN make -C $(pwd)/buildroot -j$(nproc) O=$(pwd)/build/buildroot/
+RUN rm -rf buildroot build/buildroot/build build/buildroot/staging
+# Add cross compiler path
+ENV PATH="/root/build/buildroot/host/bin:$PATH"
+# Build linux
+RUN git clone --depth 1 --branch litex-rebase https://github.com/antmicro/linux.git
+RUN make -C $(pwd)/linux -j$(nproc) O=$(pwd)/build/linux/

--- a/config.mk
+++ b/config.mk
@@ -2,6 +2,12 @@ NPROC := $(shell nproc)
 
 CROSS_COMP ?= riscv32-linux-
 
+ifeq (${GITHUB_ACTIONS}, true)
+LINUX_SOURCE    = /root/linux
+
+BUILDROOT_BUILD = /root/build/buildroot
+LINUX_BUILD     = /root/build/linux
+else
 BUILDROOT_SOURCE ?= ${TOPDIR}/third_party/buildroot
 LINUX_SOURCE     ?= ${TOPDIR}/third_party/linux
 OPENSBI_SOURCE   ?= ${TOPDIR}/third_party/opensbi
@@ -10,6 +16,7 @@ BUILDROOT_BUILD ?= ${TOPDIR}/build/buildroot
 LINUX_BUILD     ?= ${TOPDIR}/build/linux
 OPENSBI_BUILD   ?= ${TOPDIR}/build/opensbi
 VIRTIO_BUILD    ?= ${TOPDIR}/build/drive.img
+endif
 
 export ARCH=riscv
 export CROSS_COMPILE=${CROSS_COMP}

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -4,11 +4,11 @@ include ${TOPDIR}/config.mk
 
 build: dtb test modules
 
-dtb: ${TOPDIR}/build/rv32.dtb
+dtb: rv32.dtb
 test: test_app
 modules: calc_driver.ko
 
-${TOPDIR}/build/%.dtb: %.dts
+%.dtb: %.dts
 	dtc -I dts -O dtb -o $@ $^
 
 test_app: test_app.c
@@ -21,6 +21,6 @@ clean:
 	${MAKE} -C ${LINUX_SOURCE} M=${PWD} clean
 	rm -f modules.order Module.symvers *.o calc_driver.ko calc_driver.mod.c calc_driver.mod.o calc_driver.o calc_driver.mod .modules.* .Module.* .calc_driver.*
 	rm -f test_app
-	rm -f ${TOPDIR}/build/*.dtb
+	rm -f *.dtb
 
 .PHONY: clean

--- a/scripts/litex.resc
+++ b/scripts/litex.resc
@@ -5,7 +5,7 @@ machine LoadPlatformDescription @scripts/platform.repl
 showAnalyzer uart
 
 sysbus LoadBinary @build/linux/arch/riscv/boot/Image 0x40000000
-sysbus LoadBinary @build/rv32.dtb 0x40ef0000
+sysbus LoadBinary @driver/rv32.dtb 0x40ef0000
 sysbus LoadBinary @build/opensbi/platform/litex/vexriscv/firmware/fw_jump.bin 0x40f00000
 sysbus LoadBinary @build/buildroot/images/rootfs.cpio 0x42000000
 


### PR DESCRIPTION
In order to build a kernel module in CI the following steps need to be performed:
* prepare a docker image with buildroot and linux already installed
* setup GH Actions workflow