### PR TITLE
Interrupts driver

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -5,23 +5,26 @@ on: [push, pull_request]
 jobs:
   build:
     name: Builds
+    strategy:
+      matrix:
+        driver_dir: [driver_calc, driver_litex_gpio]
     runs-on: ubuntu-latest
     container: panantoni01/linux-drivers:squashed
     steps:
       - uses: actions/checkout@v4
       - name: Build modules
         run: |
-          cd driver_calc
+          cd ${{ matrix.driver_dir }}
           make modules
       - name: Build test app
         run: |
-          cd driver_calc
+          cd ${{ matrix.driver_dir }}
           make test
       - name: Build dtb
         run: |
-          cd driver_calc
+          cd ${{ matrix.driver_dir }}
           make dtb
       - uses: actions/upload-artifact@v4
         with:
-          name: Kernel modules
-          path: driver_calc/build/*.ko
+          name: "${{ matrix.driver_dir }} kernel module"
+          path: ${{ matrix.driver_dir }}/build/*.ko

--- a/driver_litex_gpio/Kbuild
+++ b/driver_litex_gpio/Kbuild
@@ -1,0 +1,1 @@
+obj-m := litex_gpio_driver.o

--- a/driver_litex_gpio/Makefile
+++ b/driver_litex_gpio/Makefile
@@ -1,0 +1,37 @@
+TOPDIR := $(realpath ..)
+
+include ${TOPDIR}/config.mk
+
+BUILD_DIR ?= $(PWD)/build
+BUILD_DIR_MAKEFILE ?= $(BUILD_DIR)/Makefile
+VIRTIO_BUILD ?= $(PWD)/drive.img
+
+build: dtb modules
+
+dtb: $(BUILD_DIR)/rv32.dtb
+modules: $(BUILD_DIR)/litex_gpio_driver.ko
+
+$(BUILD_DIR)/%.dtb: %.dts $(BUILD_DIR)
+	dtc -I dts -O dtb -o $@ $<
+
+$(BUILD_DIR)/litex_gpio_driver.ko: litex_gpio_driver.c $(BUILD_DIR_MAKEFILE)
+	${MAKE} -C ${LINUX_SOURCE} O=${LINUX_BUILD} M=${BUILD_DIR} src=$(PWD) modules
+
+$(BUILD_DIR_MAKEFILE): $(BUILD_DIR)
+	touch $@
+	
+$(BUILD_DIR):
+	mkdir -p $@
+
+build-virtio:
+	truncate -s 64M ${VIRTIO_BUILD}
+	mkfs.ext4 -d ${BUILD_DIR} ${VIRTIO_BUILD}
+
+clean-virtio:
+	rm -f ${VIRTIO_BUILD}
+
+clean: clean-virtio
+	${MAKE} -C ${LINUX_SOURCE} M=${PWD} clean
+	rm -rf $(BUILD_DIR)
+
+.PHONY: clean build-virtio clean-virtio

--- a/driver_litex_gpio/Makefile
+++ b/driver_litex_gpio/Makefile
@@ -6,13 +6,17 @@ BUILD_DIR ?= $(PWD)/build
 BUILD_DIR_MAKEFILE ?= $(BUILD_DIR)/Makefile
 VIRTIO_BUILD ?= $(PWD)/drive.img
 
-build: dtb modules
+build: dtb	test modules
 
 dtb: $(BUILD_DIR)/rv32.dtb
+test: $(BUILD_DIR)/test_app
 modules: $(BUILD_DIR)/litex_gpio_driver.ko
 
 $(BUILD_DIR)/%.dtb: %.dts $(BUILD_DIR)
 	dtc -I dts -O dtb -o $@ $<
+
+$(BUILD_DIR)/test_app: test_app.c $(BUILD_DIR)
+	$(CROSS_COMP)$(CC) -Og -Wall -o $@ $<
 
 $(BUILD_DIR)/litex_gpio_driver.ko: litex_gpio_driver.c $(BUILD_DIR_MAKEFILE)
 	${MAKE} -C ${LINUX_SOURCE} O=${LINUX_BUILD} M=${BUILD_DIR} src=$(PWD) modules

--- a/driver_litex_gpio/litex_gpio_driver.c
+++ b/driver_litex_gpio/litex_gpio_driver.c
@@ -46,6 +46,8 @@ static irqreturn_t gpio_irq_handler(int irq, void *dev_id)
 
 static int gpio_open(struct inode *inode, struct file *file)
 {
+    struct gpio_device_data *gpio_data = container_of(inode->i_cdev, struct gpio_device_data, cdev);
+    file->private_data = gpio_data;
     return 0;
 }
 

--- a/driver_litex_gpio/litex_gpio_driver.c
+++ b/driver_litex_gpio/litex_gpio_driver.c
@@ -1,0 +1,247 @@
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/mod_devicetable.h>
+#include <linux/platform_device.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+#include <linux/io.h>
+#include <linux/interrupt.h>
+#include "litex_gpio_driver.h"
+
+#define REG_GPIO_STATE       0x0
+#define REG_INTERRUPT_STATUS  0xc
+#define REG_INTERRUPT_PENDING 0x10
+#define REG_INTERRUPT_ENABLE  0x14
+
+#define GPIO_MAX_MINORS 3
+
+static int gpio_major;
+static unsigned char gpio_minors[GPIO_MAX_MINORS] = {0};
+static struct class* gpio_class;
+
+struct gpio_device_data {
+    struct cdev cdev;
+    void* __iomem base;
+    unsigned int counter;
+    spinlock_t counter_lock;
+};
+
+static inline void write_addr(u32 val, void __iomem *addr)
+{
+    writel((u32 __force)cpu_to_le32(val), addr);
+}
+
+static inline u32 read_addr(void __iomem *addr)
+{
+    return le32_to_cpu(( __le32 __force)readl(addr));
+}
+
+static irqreturn_t gpio_irq_handler(int irq, void *dev_id)
+{
+    write_addr(1, ((struct gpio_device_data *)dev_id)->base + REG_INTERRUPT_PENDING);
+    return IRQ_HANDLED;
+}
+
+static int gpio_open(struct inode *inode, struct file *file)
+{
+    return 0;
+}
+
+static ssize_t gpio_read(struct file *file, char __user *buf, size_t count, loff_t *offset)
+{
+    return 0;
+}
+
+static ssize_t gpio_write(struct file *file, const char __user *buf, size_t count, loff_t *offset) 
+{
+    return 0;
+}
+
+static long gpio_ioctl (struct file *file, unsigned int cmd, unsigned long arg) 
+{
+    return 0;
+}
+
+static int gpio_release (struct inode *inode, struct file *file)
+{
+    return 0;
+}
+
+const struct file_operations gpio_fops = {
+    .owner = THIS_MODULE,
+    .open = gpio_open,
+    .read = gpio_read,
+    .write = gpio_write,
+    .unlocked_ioctl = gpio_ioctl,
+    .release = gpio_release
+};
+
+static int get_gpio_minor(void)
+{
+    unsigned int i;
+
+    for (i = 0; i < GPIO_MAX_MINORS; i++)
+        if (gpio_minors[i] == 0)
+            return i;
+
+    return -1;
+}
+
+static int gpio_driver_probe(struct platform_device *pdev)
+{
+    struct gpio_device_data* data;
+    unsigned int minor;
+    long ret, irq;
+    struct resource* mem_res;
+
+    minor = get_gpio_minor();
+    if (minor == -1) {
+        printk(KERN_ERR "gpio_driver: reached max number of devices\n");
+        return -EIO;
+    }
+    gpio_minors[minor] = 1;
+
+    data = devm_kzalloc(&pdev->dev, sizeof(struct gpio_device_data), GFP_KERNEL);
+    if (!data) {
+        printk(KERN_ERR "gpio_driver: unable to allocate driver data\n");
+        ret = -ENOMEM;
+        goto err_min_ret;
+    }
+
+    cdev_init(&data->cdev, &gpio_fops);
+    ret = cdev_add(&data->cdev, MKDEV(gpio_major, minor), 1);
+    if (ret) {
+        printk(KERN_ERR "gpio_driver: cdev_add failed\n");
+        goto err_min_ret;
+    }
+
+    mem_res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+    if (IS_ERR(mem_res)) {
+        printk(KERN_ERR "gpio_driver: cannot get memory resource\n");
+        ret = PTR_ERR(mem_res);
+        goto err_cdev_del;
+    }
+
+    data->base = devm_ioremap_resource(&pdev->dev, mem_res);
+    if (IS_ERR(data->base)) {
+        printk(KERN_ERR "gpio_driver: cannot remap memory resource\n");
+        ret = PTR_ERR(data->base);
+        goto err_cdev_del;
+    }
+
+    irq = platform_get_irq(pdev, 0);
+    if (irq < 0) {
+        printk(KERN_ERR "gpio_driver: cannot get irq resource\n");
+        ret = irq;
+        goto err_cdev_del;
+    }
+
+    ret = devm_request_irq(&pdev->dev, irq, gpio_irq_handler, IRQF_SHARED,
+                        pdev->name, data);
+    if (ret) {
+        printk(KERN_ERR "gpio_driver: failed to request interrupt\n");
+        goto err_cdev_del;
+    }
+
+    spin_lock_init(&data->counter_lock);
+    data->counter = 0;
+
+    platform_set_drvdata(pdev, data);
+
+    if (IS_ERR(device_create(gpio_class, &pdev->dev,
+                             MKDEV(gpio_major, minor), NULL,
+                             "litex-gpio-%u", minor)))
+        printk(KERN_ERR "gpio_driver: cannot create char device\n");
+
+    write_addr(1, data->base + REG_INTERRUPT_ENABLE);
+
+    printk(KERN_INFO"gpio_driver: successful probe of device: %s\n",
+                    pdev->name);
+    return 0;
+
+err_cdev_del:
+    cdev_del(&data->cdev);
+err_min_ret:
+    gpio_minors[minor] = 0;
+    return ret;
+}
+
+static int gpio_driver_remove(struct platform_device *pdev)
+{
+    struct gpio_device_data* data;
+    struct cdev* cdev;
+    unsigned int minor;
+
+    data = platform_get_drvdata(pdev);
+    cdev = &data->cdev;
+    minor = MINOR(cdev->dev);
+    
+    cdev_del(&data->cdev);
+    gpio_minors[minor] = 0;
+
+    device_destroy(gpio_class, MKDEV(gpio_major, minor));
+
+    return 0;
+}
+
+static const struct of_device_id gpio_driver_dt_ids[] = 
+{
+    { .compatible = "litex,gpio_in" },
+    {}
+};
+
+static struct platform_driver gpio_driver = {
+    .driver = {
+        .name = "gpio_driver",
+        .of_match_table = gpio_driver_dt_ids,
+    },
+    .probe = gpio_driver_probe,
+    .remove = gpio_driver_remove,
+};
+
+int init_module(void)
+{
+    int ret;
+    dev_t dev;
+
+    ret = alloc_chrdev_region(&dev, 0, GPIO_MAX_MINORS, "gpio_driver");
+    if (ret != 0) {
+        printk(KERN_ERR "gpio_driver: cannot allocate chrdev region\n");
+        return ret;
+    }
+    gpio_major = MAJOR(dev);
+
+    gpio_class = class_create(THIS_MODULE, "gpio");
+    if (IS_ERR(gpio_class)) {
+        printk(KERN_ERR "gpio_driver: cannot create gpio class\n");
+        goto err_unreg;
+    }
+
+    ret = platform_driver_register(&gpio_driver);
+    if (ret) {
+        printk(KERN_ERR "gpio_driver: error while registering the driver\n");
+        goto err_cls;
+    }
+
+    printk(KERN_INFO "gpio_driver: successfully registered\n");
+    return 0;
+
+err_cls:
+    class_destroy(gpio_class);
+err_unreg:
+    unregister_chrdev_region(gpio_major, GPIO_MAX_MINORS);
+    return ret;
+}
+
+void cleanup_module()
+{
+    printk(KERN_INFO "gpio_driver removal\n");
+
+    unregister_chrdev_region(gpio_major, GPIO_MAX_MINORS);
+    platform_driver_unregister(&gpio_driver);
+    class_destroy(gpio_class);
+}
+
+MODULE_LICENSE ("GPL");
+MODULE_AUTHOR ("Antoni Pokusinski");
+MODULE_DESCRIPTION ("Simple driver for virtual LiteX's GPIO device");

--- a/driver_litex_gpio/litex_gpio_driver.c
+++ b/driver_litex_gpio/litex_gpio_driver.c
@@ -122,7 +122,7 @@ static int gpio_driver_probe(struct platform_device *pdev)
         goto err_cdev_del;
     }
 
-    data->base = devm_ioremap_resource(&pdev->dev, mem_res);
+    data->base = devm_ioremap(&pdev->dev, mem_res->start, resource_size(mem_res));
     if (IS_ERR(data->base)) {
         printk(KERN_ERR "gpio_driver: cannot remap memory resource\n");
         ret = PTR_ERR(data->base);

--- a/driver_litex_gpio/litex_gpio_driver.c
+++ b/driver_litex_gpio/litex_gpio_driver.c
@@ -74,6 +74,20 @@ static ssize_t gpio_write(struct file *file, const char __user *buf, size_t coun
 
 static long gpio_ioctl (struct file *file, unsigned int cmd, unsigned long arg) 
 {
+    struct gpio_device_data* gpio_data = (struct gpio_device_data*)file->private_data;
+    unsigned long flags;
+
+    switch(cmd) {
+        case GPIO_IOCTL_RESET:
+            spin_lock_irqsave(&gpio_data->counter_lock, flags);
+            gpio_data->counter = 0;
+            reinit_completion(&gpio_data->btn_press_completion);
+            spin_unlock_irqrestore(&gpio_data->counter_lock, flags);
+            break;
+        default:
+            return -EINVAL;
+    }
+
     return 0;
 }
 

--- a/driver_litex_gpio/litex_gpio_driver.c
+++ b/driver_litex_gpio/litex_gpio_driver.c
@@ -6,6 +6,7 @@
 #include <linux/cdev.h>
 #include <linux/io.h>
 #include <linux/interrupt.h>
+#include <linux/completion.h>
 #include "litex_gpio_driver.h"
 
 #define REG_GPIO_STATE       0x0
@@ -24,6 +25,7 @@ struct gpio_device_data {
     void* __iomem base;
     unsigned int counter;
     spinlock_t counter_lock;
+    struct completion btn_press_completion;
 };
 
 static inline void write_addr(u32 val, void __iomem *addr)
@@ -145,6 +147,8 @@ static int gpio_driver_probe(struct platform_device *pdev)
 
     spin_lock_init(&data->counter_lock);
     data->counter = 0;
+
+    init_completion(&data->btn_press_completion);
 
     platform_set_drvdata(pdev, data);
 

--- a/driver_litex_gpio/litex_gpio_driver.h
+++ b/driver_litex_gpio/litex_gpio_driver.h
@@ -1,0 +1,6 @@
+#ifndef _GPIO_DRIVER_H
+#define _GPIO_DRIVER_H
+
+#define GPIO_IOCTL_RESET        _IO('G', 0)
+
+#endif

--- a/driver_litex_gpio/rv32.dts
+++ b/driver_litex_gpio/rv32.dts
@@ -83,17 +83,20 @@
 		};
 	};
 
-	gpio_in@f000b000 {
+	gpio_in_1@f000b000 {
     		compatible = "litex,gpio_in";
-    		reg = <0xf000b000 0x18>;
+    		reg = <0xf000b000 0x20>;
     		status = "okay";
     		interrupt-parent = <&plic>;
     		interrupts = <3>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		button@0 {
-		  reg = <0>;
-		};
+  	};
+
+	gpio_in_2@f000c000 {
+    		compatible = "litex,gpio_in";
+    		reg = <0xf000c000 0x20>;
+    		status = "okay";
+    		interrupt-parent = <&plic>;
+    		interrupts = <3>;
   	};
 
 	aliases {

--- a/driver_litex_gpio/rv32.dts
+++ b/driver_litex_gpio/rv32.dts
@@ -1,0 +1,102 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x01>;
+	#size-cells = <0x01>;
+
+	chosen {
+		bootargs = "mem=256M@0x40000000 rootwait console=liteuart earlycon=sbi root=/dev/ram0 init=/sbin/init swiotlb=32";
+		linux,initrd-start = <0x42000000>;
+		linux,initrd-end = <0x42800000>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x5f5e100>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "riscv";
+			riscv,isa = "rv32ima_zicsr_zifencei";
+			mmu-type = "riscv,sv32";
+			reg = <0x00>;
+			status = "okay";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x01>;
+			};
+		};
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x40000000 0x10000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+
+		opensbi@40f00000 {
+			reg = <0x40f00000 0x80000>;
+		};
+	};
+
+	soc {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		bus-frequency = <0x5f5e100>;
+		compatible = "simple-bus";
+		ranges;
+
+		soc_controller@f0000000 {
+			compatible = "litex,soc_controller";
+			reg = <0xf0000000 0x0c>;
+			status = "okay";
+		};
+
+		plic: interrupt-controller@f0c00000 {
+			compatible = "sifive,plic-1.0.0\0sifive,fu540-c000-plic";
+			reg = <0xf0c00000 0x400000>;
+			#interrupt-cells = <0x01>;
+			interrupt-controller;
+			interrupts-extended = <0x01 0x0b 0x01 0x09>;
+			riscv,ndev = <0x32>;
+		};
+
+		serial@f0001000 {
+			device_type = "serial";
+			compatible = "litex,liteuart";
+			reg = <0xf0001000 0x100>;
+			status = "okay";
+		};
+		virtio@100d0000 {
+			compatible = "virtio,mmio";
+			reg = <0x100d0000 0x1000>;
+			interrupts = <2>;
+			interrupt-parent = <&plic>;
+		};
+	};
+
+	gpio_in@f000b000 {
+    		compatible = "litex,gpio_in";
+    		reg = <0xf000b000 0x18>;
+    		status = "okay";
+    		interrupt-parent = <&plic>;
+    		interrupts = <3>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		button@0 {
+		  reg = <0>;
+		};
+  	};
+
+	aliases {
+		serial0 = "/soc/serial@f0001000";
+	};
+};

--- a/driver_litex_gpio/scripts/litex.resc
+++ b/driver_litex_gpio/scripts/litex.resc
@@ -1,0 +1,5 @@
+$platform?=@driver_litex_gpio/scripts/platform.repl
+$dtb?=@driver_litex_gpio/build/rv32.dtb
+$virtio?=@driver_litex_gpio/drive.img
+
+include @scripts/litex_template.resc

--- a/driver_litex_gpio/scripts/platform.repl
+++ b/driver_litex_gpio/scripts/platform.repl
@@ -46,10 +46,18 @@ sysbus:
     init add:
         SilenceRange <4026546176 0x200> # sdram
 
-gpio_in: GPIOPort.LiteX_GPIO @ { sysbus 0xf000b000 }
+gpio_in_1: GPIOPort.LiteX_GPIO @ { sysbus 0xf000b000 }
     type: Type.In
     enableIrq : true
     IRQ -> plic@3
 
-button: Miscellaneous.Button @ gpio_in 0
-    -> gpio_in@0
+button_1: Miscellaneous.Button @ gpio_in_1 0
+    -> gpio_in_1@0
+
+gpio_in_2: GPIOPort.LiteX_GPIO @ { sysbus 0xf000c000 }
+    type: Type.In
+    enableIrq : true
+    IRQ -> plic@3
+
+button_2: Miscellaneous.Button @ gpio_in_2 0
+    -> gpio_in_2@0

--- a/driver_litex_gpio/scripts/platform.repl
+++ b/driver_litex_gpio/scripts/platform.repl
@@ -1,0 +1,55 @@
+
+rom: Memory.MappedMemory @ { sysbus 0x0 }
+    size: 0x10000
+
+sram: Memory.MappedMemory @ { sysbus 0x10000000 }
+    size: 0x2000
+
+virtio: Storage.VirtIOBlockDevice @ sysbus 0x100d0000 {IRQ -> plic@2}
+
+main_ram: Memory.MappedMemory @ { sysbus 0x40000000 }
+    size: 0x10000000
+
+spiflash: Memory.MappedMemory @ { sysbus 0xd0000000 }
+    size: 0x1000000
+
+clint: IRQControllers.CoreLevelInterruptor @ sysbus 0xf0010000
+    frequency: 100000000
+    [0, 1] -> cpu@[3, 7]
+
+plic: IRQControllers.PlatformLevelInterruptController @ sysbus 0xf0c00000
+    [0, 1] -> cpu@[11, 9]
+    numberOfSources: 32
+    numberOfContexts: 2
+    prioritiesEnabled: false
+
+cpu: CPU.VexRiscv @ sysbus
+
+    cpuType: "rv32ima_zicsr_zifencei"
+    builtInIrqController: false
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+    timeProvider: clint
+
+ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }
+
+uart: UART.LiteX_UART @ { sysbus 0xf0001000 }
+
+timer0: Timers.LiteX_Timer @ { sysbus 0xf0001800 }
+    frequency: 100000000
+
+sysbus:
+    init add:
+        SilenceRange <4026544128 0x200> # ddrphy
+
+sysbus:
+    init add:
+        SilenceRange <4026546176 0x200> # sdram
+
+gpio_in: GPIOPort.LiteX_GPIO @ { sysbus 0xf000b000 }
+    type: Type.In
+    enableIrq : true
+    IRQ -> plic@3
+
+button: Miscellaneous.Button @ gpio_in 0
+    -> gpio_in@0

--- a/driver_litex_gpio/test_app.c
+++ b/driver_litex_gpio/test_app.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello world!\n");
+    return 0;
+}

--- a/driver_litex_gpio/test_app.c
+++ b/driver_litex_gpio/test_app.c
@@ -1,6 +1,50 @@
 #include <stdio.h>
+#include <sys/stat.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "litex_gpio_driver.h"
 
-int main() {
-    printf("Hello world!\n");
+
+static void count_until(int gpio_dev_fd, unsigned int limit) {
+    unsigned int current = 0;
+
+    while (current < limit) {
+        read(gpio_dev_fd, &current, sizeof(current));
+        printf("Interrupt has been caught!\n");
+    }
+}
+
+static int is_chardev(const char* filename) {
+    struct stat file_stat;
+
+    stat(filename, &file_stat);
+    return S_ISCHR(file_stat.st_mode);
+} 
+
+int main(int argc, const char* argv[]) {
+    int fd;
+    unsigned int limit = 7;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <char_dev_file>\n", argv[0]);
+        exit(1);
+    }
+    if (!is_chardev(argv[1])) {
+        fprintf(stderr, "%s is not a character device\n", argv[1]);
+        exit(1);
+    }
+
+    fd = open(argv[1], O_RDWR);
+    assert(fd > 0);
+
+    while(1) {
+        count_until(fd, limit);
+        printf("Counter reached %d, resetting...\n", limit);
+        ioctl(fd, GPIO_IOCTL_RESET);
+    }
+
     return 0;
 }


### PR DESCRIPTION
Add a new driver for `litex_gpio` device which is a simple GPIO controller. Its model is defined in [Renode](https://github.com/renode/renode-infrastructure/blob/master/src/Emulator/Peripherals/Peripherals/GPIOPort/LiteX_GPIO.cs). 

The device raises an interrupt once a button is pressed in Renode and the goal is to implement successful interrupts handling for this device, so that it is possible to count the number of button presses.