### PR TITLE
Add driver for SI7021 device

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -7,7 +7,7 @@ jobs:
     name: Builds
     strategy:
       matrix:
-        driver_dir: [driver_calc, driver_litex_gpio]
+        driver_dir: [driver_calc, driver_litex_gpio, driver_si7021]
     runs-on: ubuntu-latest
     container: panantoni01/linux-drivers:squashed
     steps:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains source code for some Linux character device drivers that I developed as a part of the Linux drivers course at the University of Wroclaw (a.y. 2021-2022):
 * [driver_calc](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_calc) - driver of a simple arithmetic peripheral, that is capable of performing +,-,*,/ operations
 * [driver_litex_gpio](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_litex_gpio) - driver of a LiteX's GPIO device that counts the number interrupts raised from the device
+* [driver_si7021](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_si7021) - driver of Silabs' SI7021 humidity and temperature sensor, connected via I2C
 
 All the drivers can be built and run on a Vexriscv processor that is emulated in [Renode](https://github.com/renode/renode) framework.
 

--- a/driver_si7021/Kbuild
+++ b/driver_si7021/Kbuild
@@ -1,0 +1,1 @@
+obj-m := si7021_driver.o

--- a/driver_si7021/Makefile
+++ b/driver_si7021/Makefile
@@ -1,0 +1,10 @@
+TOPDIR := $(realpath ..)
+
+all: dtb test modules
+
+DTS_SRC  = rv32.dts
+MOD_SRC  = si7021_driver.c
+TEST_SRC = test_app.c
+
+include ${TOPDIR}/build_mkfiles/config.mk
+include ${TOPDIR}/build_mkfiles/common.mk

--- a/driver_si7021/README.md
+++ b/driver_si7021/README.md
@@ -1,0 +1,8 @@
+# `driver_si7021` description
+
+The driver controls a SI7021 device, which is a temperature and humidity sensor. The datasheet is available on [Silabs site](https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf). The driver provides only those functionalities that are supported by the Renode's model of the device ([link](https://github.com/renode/renode-infrastructure/blob/master/src/Emulator/Peripherals/Peripherals/Sensors/SI70xx.cs)), that is:
+* device reset by issuing `SI7021_IOCTL_RESET` ioctl
+* getting serial number of the device by issuing `SI7021_IOCTL_READ_ID` ioctl
+* getting the temperature and relative humidity measurements by reading from the character device
+
+In this example two sensors are used in the platform description: one is SI7021 and the other one is SI7006. They have different serial numbers, but all the other functionalities are exactly the same for these sensors (at least in the Renode's model).

--- a/driver_si7021/rv32.dts
+++ b/driver_si7021/rv32.dts
@@ -86,6 +86,10 @@
 			reg = <0xf0009800 0x10>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			si7021@40 {
+				compatible = "si7021";
+				reg = <0x40>;
+			};
 		};
 	};
 

--- a/driver_si7021/rv32.dts
+++ b/driver_si7021/rv32.dts
@@ -81,12 +81,22 @@
 			interrupts = <2>;
 			interrupt-parent = <&plic>;
 		};
-		i2c@f0009800 {
+		i2c_0@f0009800 {
 			compatible = "litex,i2c";
 			reg = <0xf0009800 0x10>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			si7021@40 {
+			si7021_0@40 {
+				compatible = "si7021";
+				reg = <0x40>;
+			};
+		};
+		i2c_1@f000a000 {
+			compatible = "litex,i2c";
+			reg = <0xf000a000 0x10>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			si7021_1@40 {
 				compatible = "si7021";
 				reg = <0x40>;
 			};

--- a/driver_si7021/rv32.dts
+++ b/driver_si7021/rv32.dts
@@ -1,0 +1,95 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x01>;
+	#size-cells = <0x01>;
+
+	chosen {
+		bootargs = "mem=256M@0x40000000 rootwait console=liteuart earlycon=sbi root=/dev/ram0 init=/sbin/init swiotlb=32";
+		linux,initrd-start = <0x42000000>;
+		linux,initrd-end = <0x45000000>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x5f5e100>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "riscv";
+			riscv,isa = "rv32ima_zicsr_zifencei";
+			mmu-type = "riscv,sv32";
+			reg = <0x00>;
+			status = "okay";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x01>;
+			};
+		};
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x40000000 0x10000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+
+		opensbi@40f00000 {
+			reg = <0x40f00000 0x80000>;
+		};
+	};
+
+	soc {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		bus-frequency = <0x5f5e100>;
+		compatible = "simple-bus";
+		ranges;
+
+		soc_controller@f0000000 {
+			compatible = "litex,soc_controller";
+			reg = <0xf0000000 0x0c>;
+			status = "okay";
+		};
+
+		plic: interrupt-controller@f0c00000 {
+			compatible = "sifive,plic-1.0.0\0sifive,fu540-c000-plic";
+			reg = <0xf0c00000 0x400000>;
+			#interrupt-cells = <0x01>;
+			interrupt-controller;
+			interrupts-extended = <0x01 0x0b 0x01 0x09>;
+			riscv,ndev = <0x32>;
+		};
+
+		serial@f0001000 {
+			device_type = "serial";
+			compatible = "litex,liteuart";
+			reg = <0xf0001000 0x100>;
+			status = "okay";
+		};
+		virtio@100d0000 {
+			compatible = "virtio,mmio";
+			reg = <0x100d0000 0x1000>;
+			interrupts = <2>;
+			interrupt-parent = <&plic>;
+		};
+		i2c@f0009800 {
+			compatible = "litex,i2c";
+			reg = <0xf0009800 0x10>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	aliases {
+		serial0 = "/soc/serial@f0001000";
+	};
+};

--- a/driver_si7021/scripts/litex.resc
+++ b/driver_si7021/scripts/litex.resc
@@ -1,0 +1,5 @@
+$platform?=@driver_si7021/scripts/platform.repl
+$dtb?=@driver_si7021/build/rv32.dtb
+$virtio?=@driver_si7021/drive.img
+
+include @scripts/litex_template.resc

--- a/driver_si7021/scripts/platform.repl
+++ b/driver_si7021/scripts/platform.repl
@@ -1,0 +1,52 @@
+
+rom: Memory.MappedMemory @ { sysbus 0x0 }
+    size: 0x10000
+
+sram: Memory.MappedMemory @ { sysbus 0x10000000 }
+    size: 0x2000
+
+virtio: Storage.VirtIOBlockDevice @ sysbus 0x100d0000 {IRQ -> plic@2}
+
+main_ram: Memory.MappedMemory @ { sysbus 0x40000000 }
+    size: 0x10000000
+
+spiflash: Memory.MappedMemory @ { sysbus 0xd0000000 }
+    size: 0x1000000
+
+clint: IRQControllers.CoreLevelInterruptor @ sysbus 0xf0010000
+    frequency: 100000000
+    [0, 1] -> cpu@[3, 7]
+
+plic: IRQControllers.PlatformLevelInterruptController @ sysbus 0xf0c00000
+    [0, 1] -> cpu@[11, 9]
+    numberOfSources: 32
+    numberOfContexts: 2
+    prioritiesEnabled: false
+
+cpu: CPU.VexRiscv @ sysbus
+
+    cpuType: "rv32ima_zicsr_zifencei"
+    builtInIrqController: false
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+    timeProvider: clint
+
+ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }
+
+uart: UART.LiteX_UART @ { sysbus 0xf0001000 }
+
+timer0: Timers.LiteX_Timer @ { sysbus 0xf0001800 }
+    frequency: 100000000
+
+sysbus:
+    init add:
+        SilenceRange <4026544128 0x200> # ddrphy
+
+sysbus:
+    init add:
+        SilenceRange <4026546176 0x200> # sdram
+
+i2c0: I2C.LiteX_I2C @ { sysbus 0xf0009800 }
+
+si7021: Sensors.SI70xx @ i2c0 5
+    model: Model.SI7021

--- a/driver_si7021/scripts/platform.repl
+++ b/driver_si7021/scripts/platform.repl
@@ -54,4 +54,4 @@ si7021_0: Sensors.SI70xx @ i2c0 0x40
 i2c1: I2C.LiteX_I2C @ { sysbus 0xf000a000 }
 
 si7021_1: Sensors.SI70xx @ i2c1 0x40
-    model: Model.SI7021
+    model: Model.SI7006

--- a/driver_si7021/scripts/platform.repl
+++ b/driver_si7021/scripts/platform.repl
@@ -48,5 +48,10 @@ sysbus:
 
 i2c0: I2C.LiteX_I2C @ { sysbus 0xf0009800 }
 
-si7021: Sensors.SI70xx @ i2c0 5
+si7021_0: Sensors.SI70xx @ i2c0 5
+    model: Model.SI7021
+
+i2c1: I2C.LiteX_I2C @ { sysbus 0xf000a000 }
+
+si7021_1: Sensors.SI70xx @ i2c1 5
     model: Model.SI7021

--- a/driver_si7021/scripts/platform.repl
+++ b/driver_si7021/scripts/platform.repl
@@ -48,10 +48,10 @@ sysbus:
 
 i2c0: I2C.LiteX_I2C @ { sysbus 0xf0009800 }
 
-si7021_0: Sensors.SI70xx @ i2c0 5
+si7021_0: Sensors.SI70xx @ i2c0 0x40
     model: Model.SI7021
 
 i2c1: I2C.LiteX_I2C @ { sysbus 0xf000a000 }
 
-si7021_1: Sensors.SI70xx @ i2c1 5
+si7021_1: Sensors.SI70xx @ i2c1 0x40
     model: Model.SI7021

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -3,6 +3,7 @@
 #include <linux/of.h>
 #include <linux/fs.h>
 #include <linux/cdev.h>
+#include <linux/delay.h>
 #include "si7021_driver.h"
 
 #define SI7021_MAX_MINORS 2
@@ -153,6 +154,11 @@ static int si7021_probe(struct i2c_client *client, const struct i2c_device_id *i
         dev_err_probe(&client->dev, ret, "unable to allocate driver data\n");
         goto err_min_ret;
     }
+
+    /* reset the device and wait 15ms which is the powerup time 
+    after issuing a software reset command */
+    si7021_send_cmd(client, SI7021_CMD_RESET, sizeof(u8));
+    msleep(15);
 
     cdev_init(&data->cdev, &si7021_fops);
     ret = cdev_add(&data->cdev, MKDEV(si7021_major, minor), 1);

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -1,0 +1,50 @@
+#include <linux/module.h>
+#include <linux/i2c.h>
+#include <linux/of.h>
+
+
+static int si7021_probe(struct i2c_client *client, const struct i2c_device_id *id)
+{
+    return 0;
+}
+
+static int si7021_remove(struct i2c_client *client)
+{
+	return 0;
+}
+
+
+static const struct of_device_id si7021_dt_ids[] = {
+	{ .compatible = "si7021" },
+	{ }
+};
+ MODULE_DEVICE_TABLE(of, si7021_dt_ids); /* https://stackoverflow.com/questions/22901282 */
+
+static struct i2c_driver si7021_driver = {
+	.driver = {
+		.name = "si7021",
+		.of_match_table = si7021_dt_ids,
+	},
+	.probe = si7021_probe,
+	.remove = si7021_remove,
+};
+
+static int __init si7021_init(void)
+{
+    printk(KERN_ERR"si7021_driver: successfully registered\n");
+    return i2c_add_driver(&si7021_driver);
+}
+
+static void __exit si7021_cleanup(void)
+{
+    printk(KERN_ERR"si7021_driver removal\n");
+    i2c_del_driver(&si7021_driver);
+}
+
+module_init(si7021_init);
+module_exit(si7021_cleanup);
+
+
+MODULE_LICENSE ("GPL");
+MODULE_AUTHOR ("Antoni Pokusinski");
+MODULE_DESCRIPTION ("si7021 driver");

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -1,6 +1,13 @@
 #include <linux/module.h>
 #include <linux/i2c.h>
 #include <linux/of.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+
+#define SI7021_MAX_MINORS 1
+
+static int si7021_major;
+static struct class* si7021_class;
 
 
 static int si7021_probe(struct i2c_client *client, const struct i2c_device_id *id)
@@ -31,14 +38,45 @@ static struct i2c_driver si7021_driver = {
 
 static int __init si7021_init(void)
 {
-    printk(KERN_ERR"si7021_driver: successfully registered\n");
-    return i2c_add_driver(&si7021_driver);
+    int ret;
+    dev_t dev;
+
+    ret = alloc_chrdev_region(&dev, 0, SI7021_MAX_MINORS, "si7021_driver");
+    if (ret != 0) {
+        printk(KERN_ERR "si7021_driver: cannot allocate chrdev region\n");
+        return ret;
+    }
+    si7021_major = MAJOR(dev);
+
+    si7021_class = class_create(THIS_MODULE, "thermal");
+    if (IS_ERR(si7021_class)) {
+        printk(KERN_ERR "si7021_driver: cannot create gpio class\n");
+        goto err_unreg;
+    }
+
+    ret = i2c_add_driver(&si7021_driver);
+    if (ret) {
+        printk(KERN_ERR "si7021_driver: error while registering the driver\n");
+        goto err_cls;
+    }
+
+    printk(KERN_INFO "si7021_driver: successfully registered\n");
+    return 0;
+
+err_cls:
+    class_destroy(si7021_class);
+err_unreg:
+    unregister_chrdev_region(si7021_major, SI7021_MAX_MINORS);
+    return ret;
 }
 
 static void __exit si7021_cleanup(void)
 {
     printk(KERN_ERR"si7021_driver removal\n");
+
+	unregister_chrdev_region(si7021_major, SI7021_MAX_MINORS);
     i2c_del_driver(&si7021_driver);
+	class_destroy(si7021_class);
 }
 
 module_init(si7021_init);

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -4,7 +4,7 @@
 #include <linux/fs.h>
 #include <linux/cdev.h>
 
-#define SI7021_MAX_MINORS 1
+#define SI7021_MAX_MINORS 2
 
 static int si7021_major;
 static struct class* si7021_class;

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -195,7 +195,7 @@ static int si7021_probe(struct i2c_client *client, const struct i2c_device_id *i
     after issuing a software reset command */
     ret = si7021_send_cmd(client, SI7021_CMD_RESET, sizeof(u8));
     if (ret < 0) {
-        dev_err(&client->dev, "failed to send data to si7021\n");
+        dev_err_probe(&client->dev, ret, "failed to send data to si7021\n");
         goto err_min_ret;
     }
     msleep(15);
@@ -298,9 +298,9 @@ static void __exit si7021_cleanup(void)
 {
     printk(KERN_INFO "si7021_driver removal\n");
 
-	unregister_chrdev_region(si7021_major, SI7021_MAX_MINORS);
+    unregister_chrdev_region(si7021_major, SI7021_MAX_MINORS);
     i2c_del_driver(&si7021_driver);
-	class_destroy(si7021_class);
+    class_destroy(si7021_class);
 }
 
 module_init(si7021_init);

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -26,14 +26,32 @@ struct si7021_data {
     struct i2c_client *client;
 };
 
-/* Si7021 has commands that are 1- or 2-byte long */
-static int si7021_send_cmd_8(struct i2c_client* client, u8 cmd) {
+static int si7021_send_cmd(struct i2c_client* client, u16 cmd, unsigned int size) {
+    /* Si7021 has commands that are 1- or 2-byte long */
+    if (size == 1) 
+        return i2c_master_send(client, (char*)&cmd, size);
+
+    cmd = (u16 __force)cpu_to_be16(cmd);
     return i2c_master_send(client, (char*)&cmd, sizeof(cmd));
 }
 
-static int si7021_send_cmd_16(struct i2c_client* client, u16 cmd) {
-    cmd = (u16 __force)cpu_to_be16(cmd);
-    return i2c_master_send(client, (char*)&cmd, sizeof(cmd));
+/* Helper function to issue a command and store its result in a buffer */
+static int si7021_send_cmd_and_recv(struct i2c_client* client, u16 cmd,
+                                    unsigned int cmd_size, char* buf, int size) {
+    int ret;
+
+    ret = si7021_send_cmd(client, cmd, cmd_size);
+    if (ret < 0) {
+        dev_err(&client->dev, "failed to send data to si7021\n");
+        return ret;
+    }
+    ret = i2c_master_recv(client, buf, size);
+    if (ret < 0) {
+        dev_err(&client->dev, "failed to receive data from si7021\n");
+        return ret;
+    }
+
+    return 0;
 }
 
 static int si7021_open(struct inode *inode, struct file *file)
@@ -48,32 +66,13 @@ static int si7021_open(struct inode *inode, struct file *file)
     return 0;
 }
 
-/* Helper function to issue a temperature/humidity measure command
-and read the result in a buffer */
-static int si7021_measure(struct i2c_client* client, u8 cmd, char* buf, int size) {
-    int ret;
-
-    ret = si7021_send_cmd_8(client, cmd);
-    if (ret < 0) {
-        dev_err(&client->dev, "failed to send data to si7021\n");
-        return ret;
-    }
-    ret = i2c_master_recv(client, buf, size);
-    if (ret < 0) {
-        dev_err(&client->dev, "failed to receive data from si7021\n");
-        return ret;
-    }
-
-    return 0;
-}
-
 static ssize_t si7021_read(struct file *file, char __user *buf, size_t count, loff_t *offset)
 {
     struct si7021_data* si7021_data = (struct si7021_data*)file->private_data;
     struct si7021_result result;
     int ret;
 
-    ret = si7021_measure(si7021_data->client, SI7021_CMD_TEMP_MEASURE,
+    ret = si7021_send_cmd_and_recv(si7021_data->client, SI7021_CMD_TEMP_MEASURE, sizeof(u8),
                             (char*)&result.temp, sizeof(result.temp));
     if (ret < 0)
         return ret;
@@ -81,7 +80,7 @@ static ssize_t si7021_read(struct file *file, char __user *buf, size_t count, lo
     result.temp = ((unsigned int)result.temp * 17572) / 65536 - 4685;
     result.temp /= 100;
 
-    ret = si7021_measure(si7021_data->client, SI7021_CMD_HUMI_MEASURE,
+    ret = si7021_send_cmd_and_recv(si7021_data->client, SI7021_CMD_HUMI_MEASURE, sizeof(u8),
                             (char*)&result.rl_hum, sizeof(result.rl_hum));
     if (ret < 0)
         return ret;
@@ -116,26 +115,22 @@ static long si7021_ioctl (struct file *file, unsigned int cmd, unsigned long arg
 
     switch(cmd) {
         case SI7021_IOCTL_RESET:
-            ret = si7021_send_cmd_8(client, SI7021_CMD_RESET);
-            if (ret < 0)
-                goto send_err;
+            ret = si7021_send_cmd(client, SI7021_CMD_RESET, sizeof(u8));
+            if (ret < 0) {
+                dev_err(&client->dev, "failed to send data to si7021\n");
+                return ret;
+            }
             break;
         case SI7021_IOCTL_READ_ID:
-            ret = si7021_send_cmd_16(client, SI7021_CMD_READ_ID_1);
+            ret = si7021_send_cmd_and_recv(client, SI7021_CMD_READ_ID_1, sizeof(u16),
+                                        (char *)&read_id.read_id_high, sizeof(read_id.read_id_high));
             if (ret < 0)
-                goto send_err;
-            ret = i2c_master_recv(client, (char *)&read_id.read_id_high, 
-                                    sizeof(read_id.read_id_high));
-            if (ret < 0)
-                goto recv_err;
+                return ret;
 
-            ret = si7021_send_cmd_16(client, SI7021_CMD_READ_ID_2);
+            ret = si7021_send_cmd_and_recv(client, SI7021_CMD_READ_ID_2, sizeof(u16),
+                                        (char *)&read_id.read_id_low, sizeof(read_id.read_id_low));
             if (ret < 0)
-                goto send_err;
-            ret = i2c_master_recv(client, (char *)&read_id.read_id_low,
-                                    sizeof(read_id.read_id_low));
-            if (ret < 0)
-                goto recv_err;
+                return ret;
 
             if (copy_to_user((u64*)arg, &read_id.read_id, sizeof(read_id.read_id)))
                 ret = -EFAULT;
@@ -144,12 +139,6 @@ static long si7021_ioctl (struct file *file, unsigned int cmd, unsigned long arg
             ret = -EINVAL;
     }
 
-    return ret;
-send_err:
-    dev_err(&client->dev, "failed to send data to si7021\n");
-    return ret;
-recv_err:
-    dev_err(&client->dev, "failed to receive data from si7021\n");
     return ret;
 }
 
@@ -204,7 +193,11 @@ static int si7021_probe(struct i2c_client *client, const struct i2c_device_id *i
 
     /* reset the device and wait 15ms which is the powerup time 
     after issuing a software reset command */
-    si7021_send_cmd_8(client, SI7021_CMD_RESET);
+    ret = si7021_send_cmd(client, SI7021_CMD_RESET, sizeof(u8));
+    if (ret < 0) {
+        dev_err(&client->dev, "failed to send data to si7021\n");
+        goto err_min_ret;
+    }
     msleep(15);
 
     cdev_init(&data->cdev, &si7021_fops);

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -6,6 +6,13 @@
 
 #define SI7021_MAX_MINORS 2
 
+#define SI7021_CMD_RESET 0xFE
+#define SI7021_CMD_TEMP_MEASURE 0xE3
+#define SI7021_CMD_HUMI_MEASURE 0xE5
+#define SI7021_CMD_READ_ID_1 0xFA0F
+#define SI7021_CMD_READ_ID_2 0xFCC9
+
+
 static int si7021_major;
 static unsigned char si7021_minors[SI7021_MAX_MINORS] = {0};
 static struct class* si7021_class;

--- a/driver_si7021/si7021_driver.h
+++ b/driver_si7021/si7021_driver.h
@@ -1,0 +1,7 @@
+#ifndef _SI7021_H
+#define _SI7021_H
+
+#define SI7021_IOCTL_RESET _IO('S', 0)
+#define SI7021_IOCTL_READ_ID _IOR('S', 1, long long)
+
+#endif /* _SI7021_H */

--- a/driver_si7021/si7021_driver.h
+++ b/driver_si7021/si7021_driver.h
@@ -4,4 +4,9 @@
 #define SI7021_IOCTL_RESET _IO('S', 0)
 #define SI7021_IOCTL_READ_ID _IOR('S', 1, long long)
 
+struct si7021_result {
+    short temp;
+    unsigned short rl_hum;
+};
+
 #endif /* _SI7021_H */

--- a/driver_si7021/test_app.c
+++ b/driver_si7021/test_app.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Hello world!");
+    return 0;
+}

--- a/driver_si7021/test_app.c
+++ b/driver_si7021/test_app.c
@@ -15,10 +15,24 @@ static int is_chardev(const char* filename) {
     return S_ISCHR(file_stat.st_mode);
 }
 
+static void test_read(int fd) {
+    struct si7021_result result;
+
+    if (read(fd, &result, sizeof(result)) < 0) {
+        fprintf(stderr, "si7021: read error\n");
+        exit(1);
+    }
+
+    assert(result.rl_hum >= 0 && result.rl_hum <= 100);
+    assert(result.temp >= -40 && result.temp <= 125);
+
+    printf("temperature: %d\n", result.temp);
+    printf("rl_humidity: %d\n", result.rl_hum);
+}
+
 int main(int argc, const char* argv[]) {
     int fd;
     long long serial_id;
-    struct si7021_result result;
 
     if (argc != 2) {
         fprintf(stderr, "usage: %s <char_dev_file>\n", argv[0]);
@@ -41,15 +55,9 @@ int main(int argc, const char* argv[]) {
         fprintf(stderr, "si7021: ioctl read_id error\n");
         exit(1);
     }
-    else
-        printf("serial id: %lld\n", serial_id);
+    printf("serial id: %lld\n", serial_id);
 
-    if (read(fd, &result, sizeof(result)) < 0) {
-        fprintf(stderr, "si7021: read error\n");
-        exit(1);
-    }
-    printf("temp: %d\n", result.temp);
-    printf("rl_hum: %d\n", result.rl_hum);
+    test_read(fd);
 
     return 0;
 }

--- a/driver_si7021/test_app.c
+++ b/driver_si7021/test_app.c
@@ -1,6 +1,46 @@
 #include <stdio.h>
+#include <sys/stat.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <stdlib.h>
+#include "si7021_driver.h"
 
-int main() {
-    printf("Hello world!");
+
+static int is_chardev(const char* filename) {
+    struct stat file_stat;
+
+    stat(filename, &file_stat);
+    return S_ISCHR(file_stat.st_mode);
+}
+
+int main(int argc, const char* argv[]) {
+    int fd;
+    long long serial_id;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s <char_dev_file>\n", argv[0]);
+        exit(1);
+    }
+    if (!is_chardev(argv[1])) {
+        fprintf(stderr, "%s is not a character device\n", argv[1]);
+        exit(1);
+    }
+
+    fd = open(argv[1], O_RDWR);
+    assert(fd > 0);
+
+    if (ioctl(fd, SI7021_IOCTL_RESET) < 0) {
+        fprintf(stderr, "si7021: ioctl reset error\n");
+        exit(1);
+    }
+
+    if (ioctl(fd, SI7021_IOCTL_READ_ID, &serial_id) < 0) {
+        fprintf(stderr, "si7021: ioctl read_id error\n");
+        exit(1);
+    }
+    else
+        printf("serial id: %lld\n", serial_id);
+
     return 0;
 }

--- a/driver_si7021/test_app.c
+++ b/driver_si7021/test_app.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include "si7021_driver.h"
 
 
@@ -17,6 +18,7 @@ static int is_chardev(const char* filename) {
 int main(int argc, const char* argv[]) {
     int fd;
     long long serial_id;
+    struct si7021_result result;
 
     if (argc != 2) {
         fprintf(stderr, "usage: %s <char_dev_file>\n", argv[0]);
@@ -41,6 +43,13 @@ int main(int argc, const char* argv[]) {
     }
     else
         printf("serial id: %lld\n", serial_id);
+
+    if (read(fd, &result, sizeof(result)) < 0) {
+        fprintf(stderr, "si7021: read error\n");
+        exit(1);
+    }
+    printf("temp: %d\n", result.temp);
+    printf("rl_hum: %d\n", result.rl_hum);
 
     return 0;
 }


### PR DESCRIPTION
This PR adds another driver for SI7021 humidity and temperature sensor, that is connected to LiteX I2C controller. The driver implements the following functionalities:
* i2c device registration
* accessing device registers over i2c
* character device API, as usual

The driver allows reading the temperature and humidity from the sensor and exposes it over character device API..

Device datasheet: https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf