### PR TITLE
Fixes for si7021 driver

### DIFF
--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -110,7 +110,7 @@ static ssize_t si7021_read(struct file *file, char __user *buf, size_t count, lo
         return ret;
 
     /* The relative humidity value must be in range <0,100> */
-    result.rl_hum = clamp_val(result.rl_hum, 3145, 55574);
+    result.rl_hum = clamp_val(result.rl_hum, 3146, 55574);
     result.rl_hum = ((unsigned int)result.rl_hum * 125) / 65536 - 6;
 
     if (copy_to_user(buf, &result, min(count, sizeof(result))))

--- a/driver_si7021/test_app.c
+++ b/driver_si7021/test_app.c
@@ -55,7 +55,7 @@ int main(int argc, const char* argv[]) {
         fprintf(stderr, "si7021: ioctl read_id error\n");
         exit(1);
     }
-    printf("serial id: %lld\n", serial_id);
+    printf("serial id: 0x%llx\n", serial_id);
 
     test_read(fd);
 


### PR DESCRIPTION
Some fixes are necessary for the recently added si7021 driver:
* the values obtained from the device are always in big-endian order, so it is necessary to convert them to cpu format
* the minimum code of relative humidity should be 3146 instead of 3145, so that the calculated relative humidity is always >0 (code 3145 corresponds to ~ -0.001...)