### PR TITLE
Add Renode submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-renode_portable
+.renode_libs_fetched
 build
 *.img
 *.cmd

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,7 @@
 	path = third_party/opensbi
 	url = https://github.com/litex-hub/opensbi
 	branch = 1.3.1-linux-on-litex-vexriscv
+[submodule "third_party/renode"]
+	path = third_party/renode
+	url = https://github.com/panantoni01/renode
+	branch = si7021-update

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ build-opensbi:
 		PLATFORM_RISCV_ABI=ilp32 \
 		PLATFORM_RISCV_ISA=rv32ima_zicsr_zifencei
 
+build-renode:
+	git submodule update --init ${RENODE_SOURCE}
+	cd ${RENODE_SOURCE} && bash ./build.sh -o ${RENODE_BUILD} && cd ${TOPDIR}
+
 clean-buildroot:
 	rm -rf ${BUILDROOT_BUILD}
 
@@ -35,8 +39,12 @@ clean-linux:
 clean-opensbi:
 	rm -rf ${OPENSBI_BUILD}
 
+clean-renode:
+	cd ${RENODE_SOURCE} && bash ./build.sh -c && cd ${TOPDIR}
+	rm -rf ${RENODE_BUILD}
+
 clean:
 	rm -rf ${TOPDIR}/build
 
-.PHONY: build-linux build-buildroot build-opensbi build-virtio env
-.PHONY: clean-linux clean-buildroot clean-opensbi clean-virtio clean
+.PHONY: build-linux build-buildroot build-opensbi build-renode env
+.PHONY: clean-linux clean-buildroot clean-opensbi clean-renode clean

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ All the drivers can be built and run on a Vexriscv processor that is emulated in
 ## Prerequisites
 
 ### Renode
-According to the [Renode's README](https://github.com/renode/renode/blob/master/README.rst#installation) the following commands can be executed to download the latest Renode version:
+This project uses a customized version of Renode, which is pinned as a submodule. All the prerequisites needed for building Renode from sources are described in the [Renode's documentation](https://renode.readthedocs.io/en/latest/advanced/building_from_sources.html) In order to build it one can use the command:
+```
+make build-renode
+```
+
+Downloading the latest renode tarball is also possible, however this is less recommended since it would result in a limited functionality of some devices that I used in this repository.
 ```
 wget https://dl.antmicro.com/projects/renode/builds/renode-latest.linux-portable.tar.gz
 mkdir renode_portable
@@ -43,7 +48,7 @@ Once all the files are built, one should also create a `virtio` image, which con
 ### Run Renode simulation
 First, start Renode:
 ```
-./renode_portable/renode
+./build/renode/renode
 ```
 Load the selected Renode script:
 ```

--- a/build_mkfiles/config.mk
+++ b/build_mkfiles/config.mk
@@ -11,10 +11,12 @@ else
 BUILDROOT_SOURCE ?= ${TOPDIR}/third_party/buildroot
 LINUX_SOURCE     ?= ${TOPDIR}/third_party/linux
 OPENSBI_SOURCE   ?= ${TOPDIR}/third_party/opensbi
+RENODE_SOURCE    ?= ${TOPDIR}/third_party/renode
 
 BUILDROOT_BUILD ?= ${TOPDIR}/build/buildroot
 LINUX_BUILD     ?= ${TOPDIR}/build/linux
 OPENSBI_BUILD   ?= ${TOPDIR}/build/opensbi
+RENODE_BUILD    ?= ${TOPDIR}/build/renode
 endif
 
 export ARCH=riscv

--- a/driver_calc/scripts/platform.repl
+++ b/driver_calc/scripts/platform.repl
@@ -10,12 +10,12 @@ virtio: Storage.VirtIOBlockDevice @ sysbus 0x100d0000 {IRQ -> plic@2}
 dummy_1: Python.PythonPeripheral @ { sysbus 0x100e0000 }
     size: 0x20
     initable: true
-    filename: "../driver_calc/scripts/calc_periph.py"
+    filename: "../../driver_calc/scripts/calc_periph.py"
 
 dummy_2: Python.PythonPeripheral @ { sysbus 0x100e1000 }
     size: 0x20
     initable: true
-    filename: "../driver_calc/scripts/calc_periph.py"
+    filename: "../../driver_calc/scripts/calc_periph.py"
 
 main_ram: Memory.MappedMemory @ { sysbus 0x40000000 }
     size: 0x10000000


### PR DESCRIPTION
Since some custom changes were needed for the SI7021 sensor emulation code (https://github.com/panantoni01/renode-infrastructure/tree/si7021-update), pinning Renode as a submodule was needed.
Therefore the following changes are needed:
* pin `panantoni01/renode` as a submodule in `third_party/renode`
* add `{build,clean}-renode` Makefile rules
* update `README.md` accordingly