### PR TITLE
Si7021 driver update

### DIFF
--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -84,16 +84,16 @@ static ssize_t si7021_read(struct file *file, char __user *buf, size_t count, lo
 {
     struct si7021_data* si7021_data = (struct si7021_data*)file->private_data;
     struct si7021_result result;
+    unsigned short temp_raw;
     int ret;
 
     ret = si7021_cmd_xfer(si7021_data->client, SI7021_CMD_TEMP_MEASURE, sizeof(u8),
-                          (char*)&result.temp, sizeof(result.temp));
+                          (char*)&temp_raw, sizeof(temp_raw));
     if (ret < 0)
         return ret;
 
-    result.temp = be16_to_cpu(result.temp);
-    result.temp = ((unsigned int)result.temp * 17572) / 65536 - 4685;
-    result.temp /= 100;
+    temp_raw = be16_to_cpu(temp_raw);
+    result.temp = (((int)temp_raw * 17572) / 65536 - 4685) / 100;
 
     ret = si7021_cmd_xfer(si7021_data->client, SI7021_CMD_HUMI_MEASURE, sizeof(u8),
                           (char*)&result.rl_hum, sizeof(result.rl_hum));

--- a/driver_si7021/si7021_driver.c
+++ b/driver_si7021/si7021_driver.c
@@ -26,56 +26,36 @@ struct si7021_data {
     struct i2c_client *client;
 };
 
-static int si7021_send_cmd(struct i2c_client* client, u16 cmd, unsigned int size) {
-    /* Si7021 has commands that are 1- or 2-byte long */
-    if (size == 1) 
-        return i2c_master_send(client, (char*)&cmd, size);
-
-    cmd = (u16 __force)cpu_to_be16(cmd);
-    return i2c_master_send(client, (char*)&cmd, sizeof(cmd));
-}
-
-static int si7021_recv(struct i2c_client* client, char* buf, unsigned int size) {
-    /* Si7021 may return values that are 1-, 2- or 4-byte long 
-    e.g. register value, rl_hum/temp measurement or serial number id */
-    int ret;
-    u16* ptr_16;
-    u32* ptr_32;
-
-    ret = i2c_master_recv(client, buf, size);
+static int si7021_send(struct i2c_client* client, char* buf, unsigned int size)
+{
+    int ret = i2c_master_send(client, buf, size);
     if (ret < 0)
-        return ret;
-
-    if (size == 2) {
-        ptr_16 = (u16 *)buf;
-        *ptr_16 = be16_to_cpu(( __be16 __force)(*ptr_16));
-    }
-
-    if (size == 4) {
-        ptr_32 = (u32 *)buf;
-        *ptr_32 = be32_to_cpu(( __be32 __force)(*ptr_32));
-    }
-
+        dev_err(&client->dev, "failed to send data to si7021\n");
     return ret;
 }
 
-/* Helper function to issue a command and store its result in a buffer */
-static int si7021_send_cmd_and_recv(struct i2c_client* client, u16 cmd,
-                                    unsigned int cmd_size, char* buf, int size) {
+static int si7021_send_cmd(struct i2c_client* client, u16 cmd, unsigned int size)
+{
+    return si7021_send(client, (char*)&cmd, size);
+}
+
+static int si7021_recv(struct i2c_client* client, char* buf, unsigned int size)
+{
+    int ret = i2c_master_recv(client, buf, size);
+    if (ret < 0)
+        dev_err(&client->dev, "failed to receive data from si7021\n");
+    return ret;
+}
+
+static int si7021_cmd_xfer(struct i2c_client* client, u16 cmd, unsigned int cmd_size,
+                           char* rx_buf, unsigned int rx_size)
+{
     int ret;
 
     ret = si7021_send_cmd(client, cmd, cmd_size);
-    if (ret < 0) {
-        dev_err(&client->dev, "failed to send data to si7021\n");
+    if (ret < 0)
         return ret;
-    }
-    ret = si7021_recv(client, buf, size);
-    if (ret < 0) {
-        dev_err(&client->dev, "failed to receive data from si7021\n");
-        return ret;
-    }
-
-    return 0;
+    return si7021_recv(client, rx_buf, rx_size);
 }
 
 static int si7021_open(struct inode *inode, struct file *file)
@@ -96,19 +76,21 @@ static ssize_t si7021_read(struct file *file, char __user *buf, size_t count, lo
     struct si7021_result result;
     int ret;
 
-    ret = si7021_send_cmd_and_recv(si7021_data->client, SI7021_CMD_TEMP_MEASURE, sizeof(u8),
-                            (char*)&result.temp, sizeof(result.temp));
+    ret = si7021_cmd_xfer(si7021_data->client, SI7021_CMD_TEMP_MEASURE, sizeof(u8),
+                          (char*)&result.temp, sizeof(result.temp));
     if (ret < 0)
         return ret;
 
+    result.temp = be16_to_cpu(result.temp);
     result.temp = ((unsigned int)result.temp * 17572) / 65536 - 4685;
     result.temp /= 100;
 
-    ret = si7021_send_cmd_and_recv(si7021_data->client, SI7021_CMD_HUMI_MEASURE, sizeof(u8),
-                            (char*)&result.rl_hum, sizeof(result.rl_hum));
+    ret = si7021_cmd_xfer(si7021_data->client, SI7021_CMD_HUMI_MEASURE, sizeof(u8),
+                          (char*)&result.rl_hum, sizeof(result.rl_hum));
     if (ret < 0)
         return ret;
 
+    result.rl_hum = be16_to_cpu(result.rl_hum);
     /* The relative humidity value must be in range <0,100> */
     result.rl_hum = clamp_val(result.rl_hum, 3146, 55574);
     result.rl_hum = ((unsigned int)result.rl_hum * 125) / 65536 - 6;
@@ -140,21 +122,21 @@ static long si7021_ioctl (struct file *file, unsigned int cmd, unsigned long arg
     switch(cmd) {
         case SI7021_IOCTL_RESET:
             ret = si7021_send_cmd(client, SI7021_CMD_RESET, sizeof(u8));
-            if (ret < 0) {
-                dev_err(&client->dev, "failed to send data to si7021\n");
+            if (ret < 0)
                 return ret;
-            }
             break;
         case SI7021_IOCTL_READ_ID:
-            ret = si7021_send_cmd_and_recv(client, SI7021_CMD_READ_ID_1, sizeof(u16),
-                                        (char *)&read_id.read_id_high, sizeof(read_id.read_id_high));
+            ret = si7021_cmd_xfer(client, cpu_to_be16(SI7021_CMD_READ_ID_1), sizeof(u16),
+                                  (char *)&read_id.read_id_high, sizeof(read_id.read_id_high));
             if (ret < 0)
                 return ret;
+            read_id.read_id_high = be32_to_cpu(read_id.read_id_high);
 
-            ret = si7021_send_cmd_and_recv(client, SI7021_CMD_READ_ID_2, sizeof(u16),
-                                        (char *)&read_id.read_id_low, sizeof(read_id.read_id_low));
+            ret = si7021_cmd_xfer(client, cpu_to_be16(SI7021_CMD_READ_ID_2), sizeof(u16),
+                                  (char *)&read_id.read_id_low, sizeof(read_id.read_id_low));
             if (ret < 0)
                 return ret;
+            read_id.read_id_low = be32_to_cpu(read_id.read_id_low);
 
             if (copy_to_user((u64*)arg, &read_id.read_id, sizeof(read_id.read_id)))
                 ret = -EFAULT;
@@ -218,10 +200,8 @@ static int si7021_probe(struct i2c_client *client, const struct i2c_device_id *i
     /* reset the device and wait 15ms which is the powerup time 
     after issuing a software reset command */
     ret = si7021_send_cmd(client, SI7021_CMD_RESET, sizeof(u8));
-    if (ret < 0) {
-        dev_err_probe(&client->dev, ret, "failed to send data to si7021\n");
+    if (ret < 0)
         goto err_min_ret;
-    }
     msleep(15);
 
     cdev_init(&data->cdev, &si7021_fops);

--- a/driver_si7021/si7021_driver.h
+++ b/driver_si7021/si7021_driver.h
@@ -5,6 +5,8 @@
 #define SI7021_IOCTL_READ_ID _IOR('S', 1, long long)
 #define SI7021_IOCTL_SET_USER_REG _IOW('S', 2, char)
 #define SI7021_IOCTL_GET_USER_REG _IOR('S', 3, char)
+#define SI7021_IOCTL_SET_HEATER_REG _IOW('S', 4, char)
+#define SI7021_IOCTL_GET_HEATER_REG _IOR('S', 5, char)
 
 struct si7021_result {
     short temp;

--- a/driver_si7021/si7021_driver.h
+++ b/driver_si7021/si7021_driver.h
@@ -9,4 +9,9 @@ struct si7021_result {
     unsigned short rl_hum;
 };
 
+#define SI7021_USER_REG_BIT_HEATER 2
+
+#define SI7021_HEATER_ON(user_reg)  (user_reg |= (1 << SI7021_USER_REG_BIT_HEATER))
+#define SI7021_HEATER_OFF(user_reg) (user_reg &= ~(1 << SI7021_USER_REG_BIT_HEATER))
+
 #endif /* _SI7021_H */

--- a/driver_si7021/si7021_driver.h
+++ b/driver_si7021/si7021_driver.h
@@ -3,6 +3,8 @@
 
 #define SI7021_IOCTL_RESET _IO('S', 0)
 #define SI7021_IOCTL_READ_ID _IOR('S', 1, long long)
+#define SI7021_IOCTL_SET_USER_REG _IOW('S', 2, char)
+#define SI7021_IOCTL_GET_USER_REG _IOR('S', 3, char)
 
 struct si7021_result {
     short temp;

--- a/driver_si7021/test_app.c
+++ b/driver_si7021/test_app.c
@@ -15,19 +15,109 @@ static int is_chardev(const char* filename) {
     return S_ISCHR(file_stat.st_mode);
 }
 
-static void test_read(int fd) {
-    struct si7021_result result;
-
-    if (read(fd, &result, sizeof(result)) < 0) {
+static void get_measurement(int fd, struct si7021_result* result) {
+    if (read(fd, result, sizeof(*result)) < 0) {
         fprintf(stderr, "si7021: read error\n");
         exit(1);
     }
+}
+
+static void test_read(int fd) {
+    struct si7021_result result;
+
+    get_measurement(fd, &result);
 
     assert(result.rl_hum >= 0 && result.rl_hum <= 100);
     assert(result.temp >= -40 && result.temp <= 125);
 
     printf("temperature: %d\n", result.temp);
     printf("rl_humidity: %d\n", result.rl_hum);
+}
+
+static void get_user_reg(int fd, char* user_reg) {
+    if (ioctl(fd, SI7021_IOCTL_GET_USER_REG, user_reg) < 0) {
+        fprintf(stderr, "si7021: get_user_reg ioctl error\n");
+        exit(1);
+    }
+}
+
+static void set_user_reg(int fd, char user_reg) {
+    if (ioctl(fd, SI7021_IOCTL_SET_USER_REG, user_reg) < 0) {
+        fprintf(stderr, "si7021: set_user_reg ioctl error\n");
+        exit(1);
+    }
+}
+
+static void get_heater_reg(int fd, char* heater_reg) {
+    if (ioctl(fd, SI7021_IOCTL_GET_HEATER_REG, heater_reg) < 0) {
+        fprintf(stderr, "si7021: get_heat_reg ioctl error\n");
+        exit(1);
+    }
+}
+
+static void set_heater_reg(int fd, char heater_reg) {
+    if (ioctl(fd, SI7021_IOCTL_SET_HEATER_REG, heater_reg) < 0) {
+        fprintf(stderr, "si7021: set_heat_reg ioctl error\n");
+        exit(1);
+    }
+}
+
+static void test_user_reg(int fd) {
+    char user_reg = 0;
+
+    printf("%s running...\n", __func__);
+
+    get_user_reg(fd, &user_reg);
+    assert(user_reg == 0x3A);
+
+    SI7021_HEATER_ON(user_reg);
+    set_user_reg(fd, user_reg);
+    
+    get_user_reg(fd, &user_reg);
+    assert(user_reg == 0x3E);
+
+    SI7021_HEATER_OFF(user_reg);
+    set_user_reg(fd, user_reg);
+
+    get_user_reg(fd, &user_reg);
+    assert(user_reg == 0x3A);
+
+    printf("%s succeeded!\n", __func__);
+}
+
+static void test_heater_reg(int fd) {
+    char user_reg = 0;
+    char heater_reg = 0;
+    struct si7021_result result;
+
+    printf("%s running...\n", __func__);
+
+    get_user_reg(fd, &user_reg);
+    SI7021_HEATER_ON(user_reg);
+    set_user_reg(fd, user_reg);
+
+    get_heater_reg(fd, &heater_reg);
+    assert(heater_reg == 0);
+
+    heater_reg = 0x0F;
+    set_heater_reg(fd, heater_reg);
+
+    get_heater_reg(fd, &heater_reg);
+    assert(heater_reg == 0x0F);
+
+    /* Once the heater is on, the measurements should be different */
+    get_measurement(fd, &result);
+    printf("temperature: %d\n", result.temp);
+    printf("rl_humidity: %d\n", result.rl_hum);
+
+    get_user_reg(fd, &user_reg);
+    SI7021_HEATER_OFF(user_reg);
+    set_user_reg(fd, user_reg);
+
+    heater_reg = 0;
+    set_heater_reg(fd, heater_reg);
+
+    printf("%s succeeded!\n", __func__);
 }
 
 int main(int argc, const char* argv[]) {
@@ -58,6 +148,10 @@ int main(int argc, const char* argv[]) {
     printf("serial id: 0x%llx\n", serial_id);
 
     test_read(fd);
+    test_user_reg(fd);
+    test_heater_reg(fd);
+
+    close(fd);
 
     return 0;
 }


### PR DESCRIPTION
This PR adds new functionalities of the SI7021 driver:
* implementation of `heater` and `userReg` registers in the *Renode's* emulator for the SI70xx device. Changing their values affects the temperature and humidity values returned by the device
* pin *Renode* as a submodule (required by the above-mentioned custom changes)
* new ioctls for writing/reading the `heater` and `userReg` registers
* tests for the ioctls
* macros for turning the heater on/off