### PR TITLE
Si7210 driver prerequisites

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,7 +16,7 @@ jobs:
     name: Builds
     strategy:
       matrix:
-        driver_dir: [driver_calc, driver_litex_gpio, driver_si7021]
+        driver_dir: [driver_calc, driver_litex_gpio, driver_si7021, driver_si7210]
     needs: [ verify_format ]
     runs-on: ubuntu-latest
     container: panantoni01/linux-drivers:squashed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains source code for some Linux character device drivers tha
 * [driver_calc](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_calc) - driver of a simple arithmetic peripheral, that is capable of performing +,-,*,/ operations
 * [driver_litex_gpio](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_litex_gpio) - driver of a LiteX's GPIO device that counts the number interrupts raised from the device
 * [driver_si7021](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_si7021) - driver of Silabs' SI7021 humidity and temperature sensor, connected via I2C
+* [driver_si7210](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_si7210) - IIO driver of Silabs' SI7210 magnetic sensor 
 
 All the drivers can be built and run on a Vexriscv processor that is emulated in [Renode](https://github.com/renode/renode) framework.
 

--- a/driver_si7210/Kbuild
+++ b/driver_si7210/Kbuild
@@ -1,0 +1,2 @@
+obj-m := si7210_driver.o
+

--- a/driver_si7210/Makefile
+++ b/driver_si7210/Makefile
@@ -1,0 +1,10 @@
+TOPDIR := $(realpath ..)
+
+all: dtb test modules
+
+DTS_SRC  = rv32.dts
+MOD_SRC  = si7210_driver.c
+TEST_SRC = test_app.c
+
+include ${TOPDIR}/build_mkfiles/config.mk
+include ${TOPDIR}/build_mkfiles/common.mk

--- a/driver_si7210/README.md
+++ b/driver_si7210/README.md
@@ -1,0 +1,4 @@
+# `driver_si7210` description
+
+The driver controls a Silabs' SI7210 I2C Hall Effect Magnetic Position and Temperature Sensor. The datasheet is available on [Silabs site](https://www.silabs.com/documents/public/data-sheets/si7210-datasheet.pdf).
+

--- a/driver_si7210/rv32.dts
+++ b/driver_si7210/rv32.dts
@@ -1,0 +1,99 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x01>;
+	#size-cells = <0x01>;
+
+	chosen {
+		bootargs = "mem=256M@0x40000000 rootwait console=liteuart earlycon=sbi root=/dev/ram0 init=/sbin/init swiotlb=32";
+		linux,initrd-start = <0x42000000>;
+		linux,initrd-end = <0x45000000>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x5f5e100>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "riscv";
+			riscv,isa = "rv32ima_zicsr_zifencei";
+			mmu-type = "riscv,sv32";
+			reg = <0x00>;
+			status = "okay";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x01>;
+			};
+		};
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x40000000 0x10000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+
+		opensbi@40f00000 {
+			reg = <0x40f00000 0x80000>;
+		};
+	};
+
+	soc {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		bus-frequency = <0x5f5e100>;
+		compatible = "simple-bus";
+		ranges;
+
+		soc_controller@f0000000 {
+			compatible = "litex,soc_controller";
+			reg = <0xf0000000 0x0c>;
+			status = "okay";
+		};
+
+		plic: interrupt-controller@f0c00000 {
+			compatible = "sifive,plic-1.0.0\0sifive,fu540-c000-plic";
+			reg = <0xf0c00000 0x400000>;
+			#interrupt-cells = <0x01>;
+			interrupt-controller;
+			interrupts-extended = <0x01 0x0b 0x01 0x09>;
+			riscv,ndev = <0x32>;
+		};
+
+		serial@f0001000 {
+			device_type = "serial";
+			compatible = "litex,liteuart";
+			reg = <0xf0001000 0x100>;
+			status = "okay";
+		};
+		virtio@100d0000 {
+			compatible = "virtio,mmio";
+			reg = <0x100d0000 0x1000>;
+			interrupts = <2>;
+			interrupt-parent = <&plic>;
+		};
+		i2c_0@f0009800 {
+			compatible = "litex,i2c";
+			reg = <0xf0009800 0x10>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			si7210_0@30 {
+				compatible = "si7210";
+				reg = <0x30>;
+			};
+		};
+	};
+
+	aliases {
+		serial0 = "/soc/serial@f0001000";
+	};
+};

--- a/driver_si7210/scripts/litex.resc
+++ b/driver_si7210/scripts/litex.resc
@@ -1,0 +1,5 @@
+$platform?=@driver_si7210/scripts/platform.repl
+$dtb?=@driver_si7210/build/rv32.dtb
+$virtio?=@driver_si7210/drive.img
+
+include @scripts/litex_template.resc

--- a/driver_si7210/scripts/platform.repl
+++ b/driver_si7210/scripts/platform.repl
@@ -1,0 +1,52 @@
+
+rom: Memory.MappedMemory @ { sysbus 0x0 }
+    size: 0x10000
+
+sram: Memory.MappedMemory @ { sysbus 0x10000000 }
+    size: 0x2000
+
+virtio: Storage.VirtIOBlockDevice @ sysbus 0x100d0000 {IRQ -> plic@2}
+
+main_ram: Memory.MappedMemory @ { sysbus 0x40000000 }
+    size: 0x10000000
+
+spiflash: Memory.MappedMemory @ { sysbus 0xd0000000 }
+    size: 0x1000000
+
+clint: IRQControllers.CoreLevelInterruptor @ sysbus 0xf0010000
+    frequency: 100000000
+    [0, 1] -> cpu@[3, 7]
+
+plic: IRQControllers.PlatformLevelInterruptController @ sysbus 0xf0c00000
+    [0, 1] -> cpu@[11, 9]
+    numberOfSources: 32
+    numberOfContexts: 2
+    prioritiesEnabled: false
+
+cpu: CPU.VexRiscv @ sysbus
+
+    cpuType: "rv32ima_zicsr_zifencei"
+    builtInIrqController: false
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+    timeProvider: clint
+
+ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }
+
+uart: UART.LiteX_UART @ { sysbus 0xf0001000 }
+
+timer0: Timers.LiteX_Timer @ { sysbus 0xf0001800 }
+    frequency: 100000000
+
+sysbus:
+    init add:
+        SilenceRange <4026544128 0x200> # ddrphy
+
+sysbus:
+    init add:
+        SilenceRange <4026546176 0x200> # sdram
+
+i2c0: I2C.LiteX_I2C @ { sysbus 0xf0009800 }
+
+si7021_0: Sensors.SI7210 @ i2c0 0x30
+

--- a/driver_si7210/si7210_driver.c
+++ b/driver_si7210/si7210_driver.c
@@ -1,0 +1,20 @@
+#include <linux/module.h>
+
+static int __init si7210_init(void)
+{
+  printk(KERN_INFO "s7210_driver registration\n");
+  return 0;
+}
+
+static void __exit si7210_cleanup(void)
+{
+  printk(KERN_INFO "si7210_driver removal\n");
+}
+
+module_init(si7210_init);
+module_exit(si7210_cleanup);
+
+
+MODULE_LICENSE ("GPL");
+MODULE_AUTHOR ("Antoni Pokusinski");
+MODULE_DESCRIPTION ("si7210 driver");

--- a/driver_si7210/si7210_driver.c
+++ b/driver_si7210/si7210_driver.c
@@ -2,19 +2,18 @@
 
 static int __init si7210_init(void)
 {
-  printk(KERN_INFO "s7210_driver registration\n");
-  return 0;
+	printk(KERN_INFO "s7210_driver registration\n");
+	return 0;
 }
 
 static void __exit si7210_cleanup(void)
 {
-  printk(KERN_INFO "si7210_driver removal\n");
+	printk(KERN_INFO "si7210_driver removal\n");
 }
 
 module_init(si7210_init);
 module_exit(si7210_cleanup);
 
-
-MODULE_LICENSE ("GPL");
-MODULE_AUTHOR ("Antoni Pokusinski");
-MODULE_DESCRIPTION ("si7210 driver");
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Antoni Pokusinski");
+MODULE_DESCRIPTION("si7210 driver");

--- a/driver_si7210/test_app.c
+++ b/driver_si7210/test_app.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+  printf("Hello world!\n");
+  return 0;
+}

--- a/driver_si7210/test_app.c
+++ b/driver_si7210/test_app.c
@@ -2,6 +2,6 @@
 
 int main()
 {
-  printf("Hello world!\n");
-  return 0;
+	printf("Hello world!\n");
+	return 0;
 }


### PR DESCRIPTION
The next objective is to add IIO driver for [SI7210 device](https://www.silabs.com/documents/public/data-sheets/si7210-datasheet.pdf). Hence, this PR adds some necessary files in the `si7210` directory, so that the driver itself can be implemented later:
* `scripts/{litex.resc,platform.repl}` Renode scripts
* `rv32.dts` device tree file, corresponding to the Renode's platform description file
* `si7210_driver.c` and `test_app.c` stubs of the driver and the test application
* `Makefile` and `Kbuild`, which are necessary to build the driver, test application and the device tree blob