### PR TITLE
Si7020 iio driver update

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,7 +16,7 @@ jobs:
     name: Builds
     strategy:
       matrix:
-        driver_dir: [driver_calc, driver_litex_gpio, driver_si7021, driver_si7210]
+        driver_dir: [driver_calc, driver_litex_gpio, driver_iio_si7020, driver_si7021, driver_si7210]
     needs: [ verify_format ]
     runs-on: ubuntu-latest
     container: panantoni01/linux-drivers:squashed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains source code for some Linux character device drivers tha
 * [driver_calc](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_calc) - driver of a simple arithmetic peripheral, that is capable of performing +,-,*,/ operations
 * [driver_litex_gpio](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_litex_gpio) - driver of a LiteX's GPIO device that counts the number interrupts raised from the device
 * [driver_si7021](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_si7021) - driver of Silabs' SI7021 humidity and temperature sensor, connected via I2C
+* [driver_iio_si7020](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main) - IIO driver of Silabs' SI702x sensors. This driver was not written from stratch, only the on-chip heater support was added ([link](https://github.com/torvalds/linux/commit/2aac3f9aec74b28ea73ad96efbcc0c56e5ff814f))
 * [driver_si7210](https://github.com/panantoni01/Linux_Driver_Virtual/tree/main/driver_si7210) - IIO driver of Silabs' SI7210 magnetic sensor 
 
 All the drivers can be built and run on a Vexriscv processor that is emulated in [Renode](https://github.com/renode/renode) framework.

--- a/driver_iio_si7020/Kbuild
+++ b/driver_iio_si7020/Kbuild
@@ -1,0 +1,2 @@
+obj-m := si7020_iio_driver.o
+

--- a/driver_iio_si7020/Makefile
+++ b/driver_iio_si7020/Makefile
@@ -1,0 +1,9 @@
+TOPDIR := $(realpath ..)
+
+all: dtb  modules
+
+DTS_SRC  = rv32.dts
+MOD_SRC  = si7020_iio_driver.c
+
+include ${TOPDIR}/build_mkfiles/config.mk
+include ${TOPDIR}/build_mkfiles/common.mk

--- a/driver_iio_si7020/README.md
+++ b/driver_iio_si7020/README.md
@@ -1,0 +1,5 @@
+# `driver_iio_si7020` description
+
+The driver controls a SI7021 device, which is a temperature and humidity sensor. The datasheet is available on [Silabs site](https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf).
+
+This IIO driver has already existed in the Linux kernel. With the help of this repo, the support for manipulating the integrated on-chip heater was implemented. The patch that was sent and accepted to the Linux kernel can be viewed [here](https://github.com/torvalds/linux/commit/2aac3f9aec74b28ea73ad96efbcc0c56e5ff814f)

--- a/driver_iio_si7020/rv32.dts
+++ b/driver_iio_si7020/rv32.dts
@@ -1,0 +1,99 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x01>;
+	#size-cells = <0x01>;
+
+	chosen {
+		bootargs = "mem=256M@0x40000000 rootwait console=liteuart earlycon=sbi root=/dev/ram0 init=/sbin/init swiotlb=32";
+		linux,initrd-start = <0x42000000>;
+		linux,initrd-end = <0x45000000>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x5f5e100>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "riscv";
+			riscv,isa = "rv32ima_zicsr_zifencei";
+			mmu-type = "riscv,sv32";
+			reg = <0x00>;
+			status = "okay";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x01>;
+			};
+		};
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x40000000 0x10000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+
+		opensbi@40f00000 {
+			reg = <0x40f00000 0x80000>;
+		};
+	};
+
+	soc {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		bus-frequency = <0x5f5e100>;
+		compatible = "simple-bus";
+		ranges;
+
+		soc_controller@f0000000 {
+			compatible = "litex,soc_controller";
+			reg = <0xf0000000 0x0c>;
+			status = "okay";
+		};
+
+		plic: interrupt-controller@f0c00000 {
+			compatible = "sifive,plic-1.0.0\0sifive,fu540-c000-plic";
+			reg = <0xf0c00000 0x400000>;
+			#interrupt-cells = <0x01>;
+			interrupt-controller;
+			interrupts-extended = <0x01 0x0b 0x01 0x09>;
+			riscv,ndev = <0x32>;
+		};
+
+		serial@f0001000 {
+			device_type = "serial";
+			compatible = "litex,liteuart";
+			reg = <0xf0001000 0x100>;
+			status = "okay";
+		};
+		virtio@100d0000 {
+			compatible = "virtio,mmio";
+			reg = <0x100d0000 0x1000>;
+			interrupts = <2>;
+			interrupt-parent = <&plic>;
+		};
+		i2c_0@f0009800 {
+			compatible = "litex,i2c";
+			reg = <0xf0009800 0x10>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			si7021_0@40 {
+				compatible = "si7021";
+				reg = <0x40>;
+			};
+		};
+	};
+
+	aliases {
+		serial0 = "/soc/serial@f0001000";
+	};
+};

--- a/driver_iio_si7020/scripts/litex.resc
+++ b/driver_iio_si7020/scripts/litex.resc
@@ -1,0 +1,5 @@
+$platform?=@driver_iio_si7020/scripts/platform.repl
+$dtb?=@driver_iio_si7020/build/rv32.dtb
+$virtio?=@driver_iio_si7020/drive.img
+
+include @scripts/litex_template.resc

--- a/driver_iio_si7020/scripts/platform.repl
+++ b/driver_iio_si7020/scripts/platform.repl
@@ -1,0 +1,53 @@
+
+rom: Memory.MappedMemory @ { sysbus 0x0 }
+    size: 0x10000
+
+sram: Memory.MappedMemory @ { sysbus 0x10000000 }
+    size: 0x2000
+
+virtio: Storage.VirtIOBlockDevice @ sysbus 0x100d0000 {IRQ -> plic@2}
+
+main_ram: Memory.MappedMemory @ { sysbus 0x40000000 }
+    size: 0x10000000
+
+spiflash: Memory.MappedMemory @ { sysbus 0xd0000000 }
+    size: 0x1000000
+
+clint: IRQControllers.CoreLevelInterruptor @ sysbus 0xf0010000
+    frequency: 100000000
+    [0, 1] -> cpu@[3, 7]
+
+plic: IRQControllers.PlatformLevelInterruptController @ sysbus 0xf0c00000
+    [0, 1] -> cpu@[11, 9]
+    numberOfSources: 32
+    numberOfContexts: 2
+    prioritiesEnabled: false
+
+cpu: CPU.VexRiscv @ sysbus
+
+    cpuType: "rv32ima_zicsr_zifencei"
+    builtInIrqController: false
+    privilegeArchitecture: PrivilegeArchitecture.Priv1_10
+
+    timeProvider: clint
+
+ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }
+
+uart: UART.LiteX_UART @ { sysbus 0xf0001000 }
+
+timer0: Timers.LiteX_Timer @ { sysbus 0xf0001800 }
+    frequency: 100000000
+
+sysbus:
+    init add:
+        SilenceRange <4026544128 0x200> # ddrphy
+
+sysbus:
+    init add:
+        SilenceRange <4026546176 0x200> # sdram
+
+i2c0: I2C.LiteX_I2C @ { sysbus 0xf0009800 }
+
+si7021_0: Sensors.SI70xx @ i2c0 0x40
+    model: Model.SI7006
+

--- a/driver_iio_si7020/si7020_iio_driver.c
+++ b/driver_iio_si7020/si7020_iio_driver.c
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * si7020.c - Silicon Labs Si7013/20/21 Relative Humidity and Temp Sensors
+ * Copyright (c) 2013,2014  Uplogix, Inc.
+ * David Barksdale <dbarksdale@uplogix.com>
+ */
+
+/*
+ * The Silicon Labs Si7013/20/21 Relative Humidity and Temperature Sensors
+ * are i2c devices which have an identical programming interface for
+ * measuring relative humidity and temperature. The Si7013 has an additional
+ * temperature input which this driver does not support.
+ *
+ * Data Sheets:
+ *   Si7013: http://www.silabs.com/Support%20Documents/TechnicalDocs/Si7013.pdf
+ *   Si7020: http://www.silabs.com/Support%20Documents/TechnicalDocs/Si7020.pdf
+ *   Si7021: http://www.silabs.com/Support%20Documents/TechnicalDocs/Si7021.pdf
+ */
+
+#include <linux/delay.h>
+#include <linux/i2c.h>
+#include <linux/module.h>
+#include <linux/mod_devicetable.h>
+#include <linux/slab.h>
+#include <linux/sysfs.h>
+
+#include <linux/iio/iio.h>
+#include <linux/iio/sysfs.h>
+
+/* Measure Relative Humidity, Hold Master Mode */
+#define SI7020CMD_RH_HOLD	0xE5
+/* Measure Temperature, Hold Master Mode */
+#define SI7020CMD_TEMP_HOLD	0xE3
+/* Software Reset */
+#define SI7020CMD_RESET		0xFE
+
+static int si7020_read_raw(struct iio_dev *indio_dev,
+			   struct iio_chan_spec const *chan, int *val,
+			   int *val2, long mask)
+{
+	struct i2c_client **client = iio_priv(indio_dev);
+	int ret;
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		ret = i2c_smbus_read_word_swapped(*client,
+						  chan->type == IIO_TEMP ?
+						  SI7020CMD_TEMP_HOLD :
+						  SI7020CMD_RH_HOLD);
+		if (ret < 0)
+			return ret;
+		*val = ret >> 2;
+		/*
+		 * Humidity values can slightly exceed the 0-100%RH
+		 * range and should be corrected by software
+		 */
+		if (chan->type == IIO_HUMIDITYRELATIVE)
+			*val = clamp_val(*val, 786, 13893);
+		return IIO_VAL_INT;
+	case IIO_CHAN_INFO_SCALE:
+		if (chan->type == IIO_TEMP)
+			*val = 175720; /* = 175.72 * 1000 */
+		else
+			*val = 125 * 1000;
+		*val2 = 65536 >> 2;
+		return IIO_VAL_FRACTIONAL;
+	case IIO_CHAN_INFO_OFFSET:
+		/*
+		 * Since iio_convert_raw_to_processed_unlocked assumes offset
+		 * is an integer we have to round these values and lose
+		 * accuracy.
+		 * Relative humidity will be 0.0032959% too high and
+		 * temperature will be 0.00277344 degrees too high.
+		 * This is no big deal because it's within the accuracy of the
+		 * sensor.
+		 */
+		if (chan->type == IIO_TEMP)
+			*val = -4368; /* = -46.85 * (65536 >> 2) / 175.72 */
+		else
+			*val = -786; /* = -6 * (65536 >> 2) / 125 */
+		return IIO_VAL_INT;
+	default:
+		break;
+	}
+
+	return -EINVAL;
+}
+
+static const struct iio_chan_spec si7020_channels[] = {
+	{
+		.type = IIO_HUMIDITYRELATIVE,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+			BIT(IIO_CHAN_INFO_SCALE) | BIT(IIO_CHAN_INFO_OFFSET),
+	},
+	{
+		.type = IIO_TEMP,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+			BIT(IIO_CHAN_INFO_SCALE) | BIT(IIO_CHAN_INFO_OFFSET),
+	}
+};
+
+static const struct iio_info si7020_info = {
+	.read_raw = si7020_read_raw,
+};
+
+static int si7020_probe(struct i2c_client *client,
+			const struct i2c_device_id *id)
+{
+	struct iio_dev *indio_dev;
+	struct i2c_client **data;
+	int ret;
+
+	if (!i2c_check_functionality(client->adapter,
+				     I2C_FUNC_SMBUS_WRITE_BYTE |
+				     I2C_FUNC_SMBUS_READ_WORD_DATA))
+		return -EOPNOTSUPP;
+
+	/* Reset device, loads default settings. */
+	ret = i2c_smbus_write_byte(client, SI7020CMD_RESET);
+	if (ret < 0)
+		return ret;
+	/* Wait the maximum power-up time after software reset. */
+	msleep(15);
+
+	indio_dev = devm_iio_device_alloc(&client->dev, sizeof(*data));
+	if (!indio_dev)
+		return -ENOMEM;
+
+	data = iio_priv(indio_dev);
+	*data = client;
+
+	indio_dev->name = dev_name(&client->dev);
+	indio_dev->modes = INDIO_DIRECT_MODE;
+	indio_dev->info = &si7020_info;
+	indio_dev->channels = si7020_channels;
+	indio_dev->num_channels = ARRAY_SIZE(si7020_channels);
+
+	return devm_iio_device_register(&client->dev, indio_dev);
+}
+
+static const struct i2c_device_id si7020_id[] = {
+	{ "si7020", 0 },
+	{ "th06", 0 },
+	{ }
+};
+MODULE_DEVICE_TABLE(i2c, si7020_id);
+
+static const struct of_device_id si7020_dt_ids[] = {
+	{ .compatible = "silabs,si7020" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, si7020_dt_ids);
+
+static struct i2c_driver si7020_driver = {
+	.driver = {
+		.name = "si7020",
+		.of_match_table = si7020_dt_ids,
+	},
+	.probe		= si7020_probe,
+	.id_table	= si7020_id,
+};
+
+module_i2c_driver(si7020_driver);
+MODULE_DESCRIPTION("Silicon Labs Si7013/20/21 Relative Humidity and Temperature Sensors");
+MODULE_AUTHOR("David Barksdale <dbarksdale@uplogix.com>");
+MODULE_LICENSE("GPL");

--- a/driver_iio_si7020/si7020_iio_driver.c
+++ b/driver_iio_si7020/si7020_iio_driver.c
@@ -139,21 +139,21 @@ static int si7020_probe(struct i2c_client *client,
 }
 
 static const struct i2c_device_id si7020_id[] = {
-	{ "si7020", 0 },
+	{ "my_driver_si7020", 0 },
 	{ "th06", 0 },
 	{ }
 };
 MODULE_DEVICE_TABLE(i2c, si7020_id);
 
 static const struct of_device_id si7020_dt_ids[] = {
-	{ .compatible = "silabs,si7020" },
+	{ .compatible = "si7021" },
 	{ }
 };
 MODULE_DEVICE_TABLE(of, si7020_dt_ids);
 
 static struct i2c_driver si7020_driver = {
 	.driver = {
-		.name = "si7020",
+		.name = "my_driver_si7020",
 		.of_match_table = si7020_dt_ids,
 	},
 	.probe		= si7020_probe,


### PR DESCRIPTION
The Linux Si7020 driver (which also supports other devices, e.g. Si7013 or Si7021) which is written in IIO framework, supports only reading the temperature and humidity values from the sensor.

This PR aims to add support also for manipulating the heater. It will probably require adding another channel of type `IIO_CURRENT`, implement `write_raw()` function and update the `read_raw()` function.